### PR TITLE
Pull configuration from config/home directories

### DIFF
--- a/prospector/config.py
+++ b/prospector/config.py
@@ -67,9 +67,15 @@ def build_default_sources():
 
     sources.append(build_command_line_source())
     sources.append(soc.EnvironmentVariableSource())
-    sources.append(soc.ConfigFileSource(
-        ('.prospectorrc', 'setup.cfg', 'tox.ini'),
-    ))
+    sources.append(soc.ConfigFileSource((
+        '.prospectorrc',
+        'setup.cfg',
+        'tox.ini',
+    )))
+    sources.append(soc.ConfigFileSource((
+        soc.ConfigDirectory('.prospectorrc'),
+        soc.HomeDirectory('.prospectorrc'),
+    )))
 
     return sources
 

--- a/prospector/run.py
+++ b/prospector/run.py
@@ -1,6 +1,5 @@
 import os.path
 import re
-import sys
 
 from datetime import datetime
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ _INSTALL_REQUIRES = [
     'pylint-plugin-utils>=0.1.1',
     'pylint-common>=0.1',
     'requirements-detector>=0.1.2',
-    'setoptconf',
+    'setoptconf>=0.2.0',
     'dodgy>=0.1.5',
     'pyyaml',
     'mccabe>=0.2.1',


### PR DESCRIPTION
With this PR, prospector will now check the user's home and config directories for .prospectorrc files.

It also comes with a bump for setoptconf, which has other minor fixes.
