### PR TITLE
Pyroma Ignores Path Ignore Patterns

### DIFF
--- a/prospector/tools/pyroma/__init__.py
+++ b/prospector/tools/pyroma/__init__.py
@@ -42,7 +42,7 @@ class PyromaTool(ToolBase):
 
     def run(self, found_files):
         messages = []
-        for module in found_files.iter_module_paths(include_ignored=True):
+        for module in found_files.iter_module_paths():
             dirname, filename = os.path.split(module)
             if filename != 'setup.py':
                 continue


### PR DESCRIPTION
You explicitly use `include_ignored=True` when getting the file paths for the pyroma tool, but I'm wondering why?

With this argument removed, the tool finds setup.py at the root of the project, and processes it as it should.

With this argument in place, it complains about other setup.py files that I have explicitly ignored in my profile. (E.g., Some of my projects have a "demo" directory that includes other small packages with their own setup.py. I've added the demo directory to my `ignore-patterns`, but pyroma insists on yelling at me about them.)
