### PR TITLE
Fix pydocstyle version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ _INSTALL_REQUIRES = [
     'pyflakes>=0.8.1',
     'pycodestyle==2.0.0',
     'pep8-naming>=0.3.3',
-    'pydocstyle>=1.0.0',
+    'pydocstyle>=1.0.0, <2.0.0',
 ]
 
 _PACKAGE_DATA = {


### PR DESCRIPTION
Pydocstyle does seem to have a breaking change which is not handled here and so prospector fails in a clean install with pydocstyle >=2.0.0. and pep257 checks.

2.0.0
```
 def check_source(self, source, filename, ignore_decorators):
```
https://github.com/PyCQA/pydocstyle/blob/master/src/pydocstyle/checker.py#L63

1.0.0:
```
def check_source(self, source, filename):
```
https://github.com/PyCQA/pydocstyle/blob/1.1.1/src/pydocstyle/checker.py#L46