### PR TITLE
Load pylint plugins before pylint config

### DIFF
--- a/prospector/tools/pylint/__init__.py
+++ b/prospector/tools/pylint/__init__.py
@@ -95,8 +95,8 @@ class PylintTool(ToolBase):
     def _pylintrc_configure(self, pylintrc, linter):
         errors = []
         linter.load_default_plugins()
-        linter.config_from_file(pylintrc)
-        if hasattr(linter.config, 'load_plugins'):
+        are_plugins_loaded = linter.config_from_file(pylintrc)
+        if not are_plugins_loaded and hasattr(linter.config, 'load_plugins'):
             for plugin in linter.config.load_plugins:
                 try:
                     linter.load_plugin_modules([plugin])

--- a/prospector/tools/pylint/linter.py
+++ b/prospector/tools/pylint/linter.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from pylint.__pkginfo__ import numversion as PYLINT_VERSION
 if PYLINT_VERSION >= (1, 5):
     from pylint.config import OptionsManagerMixIn
+    from pylint.utils import _splitstrip
 else:
     from logilab.common.configuration import OptionsManagerMixIn
 from pylint.lint import PyLinter
@@ -17,11 +18,18 @@ class ProspectorLinter(PyLinter):  # pylint: disable=too-many-ancestors,too-many
         PyLinter.__init__(self, *args, **kwargs)
 
     def config_from_file(self, config_file=None):
+        """Will return `True` if plugins have been loaded. For pylint>=1.5. Else `False`."""
         if PYLINT_VERSION >= (1, 5):
             self.read_config_file(config_file)
+            if self.cfgfile_parser.has_option('MASTER', 'load-plugins'):
+                # pylint: disable=protected-access
+                plugins = _splitstrip(self.cfgfile_parser.get('MASTER', 'load-plugins'))
+                self.load_plugin_modules(plugins)
             self.load_config_file()
-        else:
-            self.load_file_configuration(config_file)
+            return True
+
+        self.load_file_configuration(config_file)
+        return False
 
     def reset_options(self):
         # for example, we want to re-initialise the OptionsManagerMixin


### PR DESCRIPTION
It's the way it's done by pylint in its own runner to load the config.

This way, the plugins correctly have access to their options.

Fixes #232