### PR TITLE
Add option to set pylintrc inside prospector.yml

### DIFF
--- a/prospector/tools/pylint/__init__.py
+++ b/prospector/tools/pylint/__init__.py
@@ -154,8 +154,9 @@ class PylintTool(ToolBase):
             # try to find a .pylintrc
             pylint_options = prospector_config.tool_options('pylint')
             pylintrc = pylint_options.get('config_file')
-            if pylintrc is None:
-                pylintrc = prospector_config.external_config_location('pylint')
+            external_config = prospector_config.external_config_location('pylint')
+            if pylintrc is None or external_config:
+                pylintrc = external_config
             if pylintrc is None:
                 pylintrc = find_pylintrc()
             if pylintrc is None:

--- a/prospector/tools/pylint/__init__.py
+++ b/prospector/tools/pylint/__init__.py
@@ -152,7 +152,10 @@ class PylintTool(ToolBase):
         linter = ProspectorLinter(found_files)
         if prospector_config.use_external_config('pylint'):
             # try to find a .pylintrc
-            pylintrc = prospector_config.external_config_location('pylint')
+            pylint_options = prospector_config.tool_options('pylint')
+            pylintrc = pylint_options.get('config_file')
+            if pylintrc is None:
+                pylintrc = prospector_config.external_config_location('pylint')
             if pylintrc is None:
                 pylintrc = find_pylintrc()
             if pylintrc is None:


### PR DESCRIPTION
Fixes #231 

As mentioned in the issue above, there's no way to set inside `prospector.yml` the path for pylintrc. Instead, users have to rely on either having the `pylintrc` (or similar) being inside the project folder or through the command line option `--pylint-config-file` which can be error prone.

With this change, users can set `config_file` inside pylint options on `prospector.yml`. it'll look like:

```yaml
pylint:
  options:
    config_file: /home/xpto/projects/pylintrc
  disable:
    - bad-builtin
    - too-few-public-methods
    - missing-docstring
    - star-args
```

Also, if users set `--pylint-config-file`, it'll have priority over what was set inside `prospector.yml`.