### PR TITLE
Feature write to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ nosetests.xml
 .project
 .pydevproject
 .idea
+.vscode
 
 # Sphinx
 docs/_build

--- a/prospector/config/__init__.py
+++ b/prospector/config/__init__.py
@@ -56,17 +56,17 @@ class ProspectorConfig(object):
             runners.append(tool)
         return runners
 
-    def get_output_format(self):
+    def get_output_report(self):
         # Get the output formatter
         if self.config.output_format is not None:
-            output_format = self.config.output_format
+            output_report = self.config.output_format
         else:
-            output_format = self.profile.output_format
+            output_report = (self.profile.output_format, self.profile.output_file)
 
-        if output_format is None:
-            output_format = 'grouped'
+        if not all(output_report):
+            output_report = ('grouped', [])
 
-        return output_format
+        return output_report
 
     def _configure_prospector(self):
         # first we will configure prospector as a whole

--- a/prospector/config/__init__.py
+++ b/prospector/config/__init__.py
@@ -61,10 +61,10 @@ class ProspectorConfig(object):
         if self.config.output_format is not None:
             output_report = self.config.output_format
         else:
-            output_report = (self.profile.output_format, self.profile.output_file)
+            output_report = [(self.profile.output_format, self.profile.output_target or [])]
 
         if not all(output_report):
-            output_report = ('grouped', [])
+            output_report = [('grouped', [])]
 
         return output_report
 

--- a/prospector/config/configuration.py
+++ b/prospector/config/configuration.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import setoptconf as soc
 from prospector.__pkginfo__ import __version__
+from prospector.config.datatype import OutputChoice
 from prospector.formatters import FORMATTERS
 from prospector.tools import DEFAULT_TOOLS, TOOLS
 
@@ -29,9 +30,9 @@ def build_manager():
 
     manager.add(soc.BooleanSetting('messages_only', default=False))
     manager.add(soc.BooleanSetting('summary_only', default=False))
-    manager.add(soc.ChoiceSetting(
+    manager.add(soc.ListSetting(
         'output_format',
-        sorted(FORMATTERS.keys()),
+        OutputChoice(sorted(FORMATTERS.keys())),
         default=None,
     ))
     manager.add(soc.BooleanSetting('absolute_paths', default=False))

--- a/prospector/config/datatype.py
+++ b/prospector/config/datatype.py
@@ -1,0 +1,11 @@
+from os import pathsep
+
+from setoptconf.datatype import Choice
+
+
+class OutputChoice(Choice):
+    def sanitize(self, value):
+        splitted_value = value.split(pathsep)
+        output_format, output_targets = splitted_value[0], splitted_value[1:]
+        validated_format =  super(OutputChoice, self).sanitize(output_format)
+        return (output_format, output_targets)

--- a/prospector/profiles/profile.py
+++ b/prospector/profiles/profile.py
@@ -46,6 +46,7 @@ class ProspectorProfile(object):
         )
 
         self.output_format = profile_dict.get('output-format')
+        self.output_target = profile_dict.get('output-target')
         self.autodetect = profile_dict.get('autodetect')
         self.uses = [uses for uses in _ensure_list(profile_dict.get('uses', []))
                      if uses in ('django', 'celery', 'flask')]
@@ -92,6 +93,7 @@ class ProspectorProfile(object):
             'ignore-paths': self.ignore_paths,
             'ignore-patterns': self.ignore_patterns,
             'output-format': self.output_format,
+            'output-file': self.output_file,
             'autodetect': self.autodetect,
             'uses': self.uses,
             'max-line-length': self.max_line_length,

--- a/prospector/run.py
+++ b/prospector/run.py
@@ -123,20 +123,28 @@ class Prospector(object):
     def get_messages(self):
         return self.messages
 
-    def print_messages(self, write_to=None):
-        write_to = write_to or sys.stdout
+    def print_messages(self):
+        output_reports = self.config.get_output_report()
 
-        output_format = self.config.get_output_format()
-        self.summary['formatter'] = output_format
-        formatter = FORMATTERS[output_format](self.summary, self.messages, self.config.profile)
+        for report in output_reports:
+            output_format, output_files = report
+            self.summary['formatter'] = output_format
+            formatter = FORMATTERS[output_format](self.summary, self.messages, self.config.profile)
+            if not output_files:
+                self.write_to(formatter, sys.stdout)
+            for output_file in output_files:
+                with open(output_file, 'w+') as target:
+                    self.write_to(formatter, target)
 
+    def write_to(self, formatter, target):
         # Produce the output
-        write_to.write(formatter.render(
+        target.write(formatter.render(
             summary=not self.config.messages_only,
             messages=not self.config.summary_only,
             profile=self.config.show_profile
         ))
-        write_to.write('\n')
+        target.write('\n')
+
 
 
 def get_parser():


### PR DESCRIPTION
Resolves #246.

As of now, there's no way to way to redirect output to files. This implementation was inspired on how it was described on #246 and how `pytest-cov` redirects its output. It's also possible to set multiple outputs for the same export, so if one runs `prospector -o xunit:output_file.xml:/home/xpto/output_file.xml` it'll write to both relative `output_file.xml` and absolute `/home/xpto/output_file.xml`. Multiple reports are also supported, so `prospector -o xunit:output_file.xml -o grouped` will write XUnit format to output to relative `output_file.xml` and grouped format on console.