### PR TITLE
Bugfix report different behavior based on path

### DIFF
--- a/prospector/blender_combinations.yaml
+++ b/prospector/blender_combinations.yaml
@@ -148,6 +148,7 @@ combinations:
     -   # No exception type(s) specified
         - pylint: bare-except
         - frosted: W101
+        - pep8: E722
 
     -   # Spaces around keyword/paramater equals
         - pep8: E251

--- a/prospector/config/__init__.py
+++ b/prospector/config/__init__.py
@@ -24,11 +24,7 @@ class ProspectorConfig(object):
 
         self.paths = self._get_work_path(self.config, self.arguments)
         self.explicit_file_mode = all(map(os.path.isfile, self.paths))
-
-        if os.path.isdir(self.paths[0]):
-            self.workdir = self.paths[0]
-        else:
-            self.workdir = os.getcwd()
+        self.workdir = os.getcwd()
 
         self.profile, self.strictness = self._get_profile(self.workdir, self.config)
         self.libraries = self._find_used_libraries(self.config, self.profile)

--- a/prospector/config/__init__.py
+++ b/prospector/config/__init__.py
@@ -57,10 +57,11 @@ class ProspectorConfig(object):
         if self.config.output_format is not None:
             output_report = self.config.output_format
         else:
-            output_report = [(self.profile.output_format, self.profile.output_target or [])]
+            output_report = [(self.profile.output_format, self.profile.output_target)]
 
-        if not all(output_report):
-            output_report = [('grouped', [])]
+        for index, report in enumerate(output_report):
+            if not all(report):
+                output_report[index] = (report[0] or 'grouped', report[1] or [])
 
         return output_report
 

--- a/prospector/finder.py
+++ b/prospector/finder.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*-
 import os
+
 from prospector.pathutils import is_virtualenv
 
 
@@ -187,7 +189,7 @@ def _find_paths(ignore, curpath, rootpath):
     return files, modules, packages, directories
 
 
-def find_python(ignores, paths, explicit_file_mode, workdir=None):
+def find_python(ignores, paths, explicit_file_mode, workdir=''):
     """
     Returns a FoundFiles class containing a list of files, packages, directories,
     where files are simply all python (.py) files, packages are directories
@@ -198,5 +200,5 @@ def find_python(ignores, paths, explicit_file_mode, workdir=None):
         return SingleFiles(paths, workdir or os.getcwd())
     else:
         assert len(paths) == 1
-        files, modules, directories, packages = _find_paths(ignores, paths[0], paths[0])
-        return FoundFiles(paths[0], files, modules, directories, packages, ignores)
+        files, modules, directories, packages = _find_paths(ignores, paths[0], workdir)
+        return FoundFiles(workdir, files, modules, directories, packages, ignores)

--- a/prospector/postfilter.py
+++ b/prospector/postfilter.py
@@ -30,7 +30,7 @@ def filter_messages(relative_filepaths, root, messages):
         # first get rid of the pylint informational messages
         relative_message_path = os.path.relpath(message.location.path)
 
-        if message.source == 'pylint' and message.code in ('suppressed-message',):
+        if message.source == 'pylint' and message.code in ('suppressed-message', 'file-ignored',):
             continue
 
         # some files are skipped entirely by messages

--- a/tests/finder/test_file_finder.py
+++ b/tests/finder/test_file_finder.py
@@ -1,16 +1,17 @@
+# -*- coding: utf-8 -*-
 import os
 from unittest import TestCase
+
 from prospector.finder import find_python
 from prospector.pathutils import is_virtualenv
 
 
 class TestSysPath(TestCase):
-
     def _run_test(self, name, expected):
         root = os.path.join(os.path.dirname(__file__), 'testdata', name)
         files = find_python([], [root], explicit_file_mode=False)
 
-        expected = [os.path.join(root, e).rstrip(os.path.sep) for e in expected]
+        expected = [os.path.relpath(os.path.join(root, e).rstrip(os.path.sep)) for e in expected]
         actual = files.get_minimal_syspath()
 
         expected.sort(key=lambda x: len(x))

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,4 @@ skip_missing_interpreters = true
 deps =
     nose
     py27: mock
-commands = nosetests tests
+commands = nosetests tests {posargs}


### PR DESCRIPTION
Resolves #257.

@carlio this will really need your input on it. To summarize, that was a point where `prospector` would give different results, this should be fixed. Also, `pep8linter` was not using all found files depending on the path it was called.