### PR TITLE
Fix read_config_file using quiet keyword with older pylint versions

### DIFF
--- a/prospector/tools/pylint/linter.py
+++ b/prospector/tools/pylint/linter.py
@@ -21,9 +21,9 @@ class ProspectorLinter(PyLinter):  # pylint: disable=too-many-ancestors,too-many
         """Will return `True` if plugins have been loaded. For pylint>=1.5. Else `False`."""
         if PYLINT_VERSION >= (1, 5):
             if PYLINT_VERSION >= (2, 0):
-                self.read_config_file(config_file, quiet=True)
-            else:
                 self.read_config_file(config_file)
+            else:
+                self.read_config_file(config_file, quiet=True)
             if self.cfgfile_parser.has_option('MASTER', 'load-plugins'):
                 # pylint: disable=protected-access
                 plugins = _splitstrip(self.cfgfile_parser.get('MASTER', 'load-plugins'))


### PR DESCRIPTION
When the previous change was implemented to allow the `config_from_file`
method within the pylint tools to use the `quiet` keyword in older
versions of pylint, the `quiet` keyword was added to the if block when
the pylint version is 2.0 or greater instead of the else block for when
the pylint version is less than (older) than 2.0