### PR TITLE
Removing pylint common

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 # http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
-sudo: false
+language: python
 python:
   - "2.7"
   - "3.4"
@@ -23,4 +23,10 @@ script:
   - "coverage combine"
   - "coverage report --show-missing"
 after_success:
-  coveralls
+  - |
+      prospector -0
+      coveralls
+notifications:
+  email:
+    on_failure: change
+    on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ python:
   - "3.7-dev"
 install:
   - "pip install nose coverage coveralls mock"
-  - "pip install git+https://github.com/landscapeio/pylint-plugin-utils.git@master"
-  - "pip install git+https://github.com/landscapeio/pylint-common.git@master"
-  - "pip install git+https://github.com/landscapeio/requirements-detector.git@master"
-  # reason: https://github.com/yaml/pyyaml/issues/126
-  - "pip install git+https://github.com/yaml/pyyaml.git@master"
   - "pip install --editable ."
 script:
   - "nosetests -s --with-coverage --cover-inclusive --cover-package=prospector tests/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Prospector Changelog
 =======
 
+## Version 1.1.1
+- Removing [pylint-common](https://github.com/landscapeio/pylint-common) as a direct dependency as it does not add a lot of utility and is not kept up to date as much as other plugins
+
 ## Version 1.1
 - [#267](https://github.com/PyCQA/prospector/pull/267) Fix read_config_file using quiet keyword with older pylint versions
 - [#262](https://github.com/PyCQA/prospector/pull/262) Bugfix report different behavior based on path(includes KeyError on FORMATTERS fix)

--- a/prospector/__pkginfo__.py
+++ b/prospector/__pkginfo__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-__version_info__ = (1, 1)
+__version_info__ = (1, 1, 1)
 __version__ = '.'.join(map(str, __version_info__))

--- a/prospector/config/configuration.py
+++ b/prospector/config/configuration.py
@@ -19,7 +19,6 @@ def build_manager():
     manager.add(soc.ListSetting('uses', soc.String, default=[]))
 
     manager.add(soc.BooleanSetting('blending', default=True))
-    manager.add(soc.BooleanSetting('common_plugin', default=True))
 
     manager.add(soc.BooleanSetting('doc_warnings', default=None))
     manager.add(soc.BooleanSetting('test_warnings', default=None))
@@ -125,9 +124,6 @@ def build_command_line_source(prog=None, description='Performs static analysis o
                     ' together messages from different tools if they represent'
                     ' the same error. Use this option to see all unmerged'
                     ' messages.',
-        },
-        'common_plugin': {
-            'flags': ['--no-common-plugin'],
         },
         'doc_warnings': {
             'flags': ['-D', '--doc-warnings'],

--- a/prospector/tools/pylint/__init__.py
+++ b/prospector/tools/pylint/__init__.py
@@ -28,7 +28,6 @@ class PylintTool(ToolBase):
 
     def _prospector_configure(self, prospector_config, linter):
         linter.load_default_plugins()
-        linter.load_plugin_modules(['pylint_common'])
 
         if 'django' in prospector_config.libraries:
             linter.load_plugin_modules(['pylint_django'])

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ _PACKAGES = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
 
 _INSTALL_REQUIRES = [
     'pylint-plugin-utils>=0.2.6',
-    'pylint-common>=0.2.5',
     'requirements-detector>=0.6',
     'setoptconf>=0.2.0',
     'dodgy>=0.1.9',


### PR DESCRIPTION
pylint-common is an unecessary dependency and adds additional 'cogs' to keep up to date with. It only has one augmentation which if necessary could be moved into prospector directly,