### PR TITLE
[mypy] Add strict option and fixed emacs output format

### DIFF
--- a/prospector/tools/mypy/__init__.py
+++ b/prospector/tools/mypy/__init__.py
@@ -76,7 +76,7 @@ class MypyTool(ToolBase):
 
         for message in report.splitlines():
             iter_message = iter(message.split(':'))
-            (path, line, char, err_type), err_msg = islice(iter_message, 4), list(message)
+            (path, line, char, err_type, err_msg) = islice(iter_message, 5)
             location = Location(
                 path=path,
                 module=None,
@@ -89,7 +89,7 @@ class MypyTool(ToolBase):
                 source='mypy',
                 code=err_type.lstrip(" "),
                 location=location,
-                message=''.join(err_msg).strip()
+                message=err_msg.lstrip(" ")
             )
             messages.append(message)
 

--- a/prospector/tools/mypy/__init__.py
+++ b/prospector/tools/mypy/__init__.py
@@ -30,7 +30,7 @@ class MypyTool(ToolBase):
     def configure(self, prospector_config, _):
         options = prospector_config.tool_options('mypy')
         
-        mypy_ini = options.get('config-file', None)
+        strict = options.get('strict', False)
 
         follow_imports = options.get('follow-imports', 'normal')
         ignore_missing_imports = options.get('ignore-missing-imports', False)
@@ -42,8 +42,8 @@ class MypyTool(ToolBase):
 
         self.options.append('--follow-imports=%s' % follow_imports)
         
-        if mypy_ini:
-            self.options.append('--config-file mypy_ini')
+        if strict:
+            self.options.append('--strict')
 
         if ignore_missing_imports:
             self.options.append('--ignore-missing-imports')

--- a/prospector/tools/mypy/__init__.py
+++ b/prospector/tools/mypy/__init__.py
@@ -82,7 +82,7 @@ class MypyTool(ToolBase):
                 module=None,
                 function=None,
                 line=line,
-                character=char,
+                character=int(char),
                 absolute_path=True
             )
             message = Message(

--- a/prospector/tools/mypy/__init__.py
+++ b/prospector/tools/mypy/__init__.py
@@ -87,7 +87,7 @@ class MypyTool(ToolBase):
             )
             message = Message(
                 source='mypy',
-                code=err_type,
+                code=err_type.lstrip(" "),
                 location=location,
                 message=''.join(err_msg).strip()
             )

--- a/prospector/tools/mypy/__init__.py
+++ b/prospector/tools/mypy/__init__.py
@@ -29,6 +29,8 @@ class MypyTool(ToolBase):
 
     def configure(self, prospector_config, _):
         options = prospector_config.tool_options('mypy')
+        
+        mypy_ini = options.get('config-file', None)
 
         follow_imports = options.get('follow-imports', 'normal')
         ignore_missing_imports = options.get('ignore-missing-imports', False)
@@ -39,6 +41,9 @@ class MypyTool(ToolBase):
         strict_optional = options.get('strict-optional', False)
 
         self.options.append('--follow-imports=%s' % follow_imports)
+        
+        if mypy_ini:
+            self.options.append('--config-file mypy_ini')
 
         if ignore_missing_imports:
             self.options.append('--ignore-missing-imports')


### PR DESCRIPTION
I am not sure if you like it, though I really like using `--strict` when lint with mypy.