### PR TITLE
Remove unexpected argument from read_config_file

### DIFF
--- a/prospector/tools/pylint/linter.py
+++ b/prospector/tools/pylint/linter.py
@@ -20,10 +20,7 @@ class ProspectorLinter(PyLinter):  # pylint: disable=too-many-ancestors,too-many
     def config_from_file(self, config_file=None):
         """Will return `True` if plugins have been loaded. For pylint>=1.5. Else `False`."""
         if PYLINT_VERSION >= (1, 5):
-            if PYLINT_VERSION >= (2, 0):
-                self.read_config_file(config_file)
-            else:
-                self.read_config_file(config_file, quiet=True)
+            self.read_config_file(config_file)
             if self.cfgfile_parser.has_option('MASTER', 'load-plugins'):
                 # pylint: disable=protected-access
                 plugins = _splitstrip(self.cfgfile_parser.get('MASTER', 'load-plugins'))


### PR DESCRIPTION
This change fixes the error `TypeError read_config_file() got an unexpected keyword argument quiet`

PyLint version 2 introduced the verbose argument in `read_config_file`, which defaults to `None`. I believe there is no reason to perform any version check, unless the `verbose` argument has to be set to anything other than `None`