### PR TITLE
Add a pre-commit hook for running Prospector

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: prospector
+    name: prospector
+    description: Analyze Python code using Prospector
+    entry: prospector
+    language: python
+    types: [python]


### PR DESCRIPTION
This adds a [pre-commit](https://pre-commit.com)-hook for running
Prospector against all changed Python files of a git commit.