### PR TITLE
Version 1.1.4  -  fixing dependency resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Prospector Changelog
 =======
 
+## Version 1.1.4
+- [#285](https://github.com/PyCQA/prospector/issues/285) Fix dependency tree resolution - now insists on `pep8-naming<=0.4.1` as later versions cause conflicting versions of flake8 to be installed.
+
 ## Version 1.1.3
 - [#279](https://github.com/PyCQA/prospector/issues/279) Fix --show-profile crash
 

--- a/prospector/__pkginfo__.py
+++ b/prospector/__pkginfo__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-__version_info__ = (1, 1, 3)
+__version_info__ = (1, 1, 4)
 __version__ = '.'.join(map(str, __version_info__))

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ _INSTALL_REQUIRES = [
     'mccabe>=0.5.0',
     'pyflakes<2.0.0,>=0.8.1',
     'pycodestyle<2.4.0,>=2.0.0',
-    'pep8-naming>=0.3.3',
+    'pep8-naming>=0.3.3,<=0.4.1',
     'pydocstyle>=2.0.0',
 ]
 


### PR DESCRIPTION
After flake8 3.6.0 was released, prospector's dependency tree broke - see #285 

The quick solution was to pin pep8-naming to an older version which did not end up including flake8 as a dependency which is where the conflicts came from.

At least for now this will get builds working again for people.