### PR TITLE
More generic path separator for --output-format output files

### DIFF
--- a/prospector/config/configuration.py
+++ b/prospector/config/configuration.py
@@ -164,7 +164,7 @@ def build_command_line_source(prog=None, description='Performs static analysis o
         },
         'output_format': {
             'flags': ['-o', '--output-format'],
-            'help': 'The output format. Valid values are: %s' % (
+            'help': 'The output format. Valid values are: %s. This will output to stdout by default, however a target file can be used instead by adding :path-to-output-file, eg, -o json:output.json' % (
                 ', '.join(sorted(FORMATTERS.keys())),
             ),
         },

--- a/prospector/config/datatype.py
+++ b/prospector/config/datatype.py
@@ -1,11 +1,11 @@
-from os import pathsep
+import re
 
 from setoptconf.datatype import Choice
 
 
 class OutputChoice(Choice):
     def sanitize(self, value):
-        splitted_value = value.split(pathsep)
-        output_format, output_targets = splitted_value[0], splitted_value[1:]
+        parsed = re.split(r'[;:]', value)
+        output_format, output_targets = parsed[0], parsed[1:]
         validated_format =  super(OutputChoice, self).sanitize(output_format)
         return (output_format, output_targets)


### PR DESCRIPTION
[fixes #296] Splitting output format from output file(s) using generic separator rather than OS specific path separator

Rather than us `os.pathsep`, just specify that the prospector always takes a colon (though `;` still works in case people have that build config still)