### PR TITLE
Pin pylint to 2.1.1

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-pyenv activate prospector-versions
-

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ docs/_build
 # emacs
 TAGS
 flycheck*
+
+# local configuration
+.env

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ _INSTALL_REQUIRES = [
 if sys.version_info < (3, 0):
     _INSTALL_REQUIRES += ['pylint<2', 'pylint-django<0.9']
 else:
-    _INSTALL_REQUIRES += ['pylint>=2', 'pylint-django==2.0.2']
+    _INSTALL_REQUIRES += ['pylint==2.1.1', 'pylint-django==2.0.2']
 
 _PACKAGE_DATA = {
     'prospector': [


### PR DESCRIPTION
Fixes #303 

Pinning pylint version as current release/master is not compatible with pylint 2.2.0 yet. For a quick bugfix release (as this is breaking builds everywhere) this will do for now and a proper fix will go into release 1.1.7 .