### PR TITLE
Pin astroid version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ Prospector Changelog
 
 ## Version 1.1.6.2 (placeholder for release)
 - [#304](https://github.com/PyCQA/prospector/pull/304) Pin pylint to 2.1.1 for now as prospector is not compatible with 2.2.0
- 
+- [#302](https://github.com/PyCQA/prospector/issues/302) Pin astroid to 2.0.4 as pylint-django and pylint-flask need fixes to be compatible with newer versions 
+
 ## Version 1.1.6.1
 - [#292](https://github.com/PyCQA/prospector/issues/292) Adding pylint plugin dependencies back and fixing autodetect behaviour.
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ _INSTALL_REQUIRES = [
 if sys.version_info < (3, 0):
     _INSTALL_REQUIRES += ['pylint<2', 'pylint-django<0.9']
 else:
-    _INSTALL_REQUIRES += ['pylint==2.1.1', 'pylint-django==2.0.2']
+    _INSTALL_REQUIRES += ['pylint==2.1.1', 'pylint-django==2.0.2', 'astroid==2.0.4']
 
 _PACKAGE_DATA = {
     'prospector': [


### PR DESCRIPTION
[fixes #302] Pin astroid to 2.0.4 as some dependencies do not work with latest astroid release

Related to #303 and #304 as well.