### PR TITLE
Release 1.1.6.2

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+pyenv activate prospector-versions
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 Prospector Changelog
 =======
 
-## Version 1.1.6 (placeholder for release)
+## Version 1.1.6.2 (placeholder for release)
+- [#304](https://github.com/PyCQA/prospector/pull/304) Pin pylint to 2.1.1 for now as prospector is not compatible with 2.2.0
+ 
+## Version 1.1.6.1
 - [#292](https://github.com/PyCQA/prospector/issues/292) Adding pylint plugin dependencies back and fixing autodetect behaviour.
 
 # Version 1.1.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Prospector Changelog
 =======
 
-## Version 1.1.6.2 (placeholder for release)
+## Version 1.1.6.2
 - [#304](https://github.com/PyCQA/prospector/pull/304) Pin pylint to 2.1.1 for now as prospector is not compatible with 2.2.0
 - [#302](https://github.com/PyCQA/prospector/issues/302) Pin astroid to 2.0.4 as pylint-django and pylint-flask need fixes to be compatible with newer versions 
 

--- a/prospector/__pkginfo__.py
+++ b/prospector/__pkginfo__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-__version_info__ = (1, 1, 6, 1)
+__version_info__ = (1, 1, 6, 2)
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
Pinning pylint/astroid versions as sub-dependencies and prospector are not compatibile with most recent releases of both.