### PR TITLE
Remove the pylint locally-enabled message suppression

### DIFF
--- a/prospector/tools/pylint/__init__.py
+++ b/prospector/tools/pylint/__init__.py
@@ -62,8 +62,6 @@ class PylintTool(ToolBase):
         # was disabled.
         linter.disable(
             'locally-disabled')  # notification about disabling a message
-        linter.disable(
-            'locally-enabled')  # notification about enabling a message
         linter.enable(
             'file-ignored')  # notification about disabling an entire file
         linter.enable('suppressed-message'


### PR DESCRIPTION
As of pylint 2.2 this message is no longer present in pylint, and
hence does not need suppressing. Sadly however this line errors with pylint>= 2.2 and hence needs removing.