### PR TITLE
bump pylint-flask 0.5->0.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ _PACKAGES = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
 _INSTALL_REQUIRES = [
     'pylint-plugin-utils>=0.2.6',
     'pylint-celery==0.3',
-    'pylint-flask==0.5',
+    'pylint-flask==0.6',
     'requirements-detector>=0.6',
     'setoptconf>=0.2.0',
     'dodgy>=0.1.9',


### PR DESCRIPTION
astroid 2 doesn't seem to be compatible with pylint-flask. This is
documented at https://github.com/jschaf/pylint-flask/pull/9.
pylint-flask 0.6 fixes this. prospector currently pulls in astroid 2.0.4
and pylint-flask 0.5. This commit fixes it.