### PR TITLE
Add support pylint --load-plugins option in profile

### DIFF
--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -142,6 +142,20 @@ but you can turn it on using the ``--member-warnings`` flag or in a profile::
     member-warnings: true
 
 
+Pylint Plugins
+'''''''''''''''
+
+It is possible to specify list of plugins for Pylint. You can do this by using ``load-plugins``
+option in ``pylint`` section::
+
+    pylint:
+        load-plugins:
+            - plugin
+            - plugin
+
+Note that this option doesn't affect loading of :ref:`autodetected plugins <libraries-used-and-autodetect>`.
+
+
 PEP8 Control
 ............
 

--- a/prospector/profiles/profile.py
+++ b/prospector/profiles/profile.py
@@ -173,7 +173,9 @@ def _simple_merge_dict(priority, base):
 def _merge_tool_config(priority, base):
     out = dict(base.items())
     for key, value in priority.items():
-        if key in ('run', 'full', 'none'):  # pep8 has extra 'full' and 'none' options
+        # pep8 has extra 'full' and 'none' options
+        # pylint has extra 'load-plugins' option
+        if key in ('run', 'full', 'none', 'load-plugins'):
             out[key] = value
         elif key in ('options',):
             out[key] = _simple_merge_dict(value, base.get(key, {}))

--- a/prospector/tools/pylint/__init__.py
+++ b/prospector/tools/pylint/__init__.py
@@ -27,6 +27,7 @@ class PylintTool(ToolBase):
         self._orig_sys_path = []
 
     def _prospector_configure(self, prospector_config, linter):
+        errors = []
         linter.load_default_plugins()
 
         if 'django' in prospector_config.libraries:
@@ -35,6 +36,16 @@ class PylintTool(ToolBase):
             linter.load_plugin_modules(['pylint_celery'])
         if 'flask' in prospector_config.libraries:
             linter.load_plugin_modules(['pylint_flask'])
+
+        profile_path = os.path.join(
+            prospector_config.workdir, prospector_config.profile.name)
+        for plugin in prospector_config.profile.pylint.get('load-plugins', []):
+            try:
+                linter.load_plugin_modules([plugin])
+            except ImportError:
+                errors.append(
+                    self._error_message(
+                        profile_path, "Could not load plugin %s" % plugin))
 
         for msg_id in prospector_config.get_disabled_messages('pylint'):
             try:
@@ -91,6 +102,7 @@ class PylintTool(ToolBase):
                 if max_line_length is not None:
                     if option[0] == 'max-line-length':
                         checker.set_option('max-line-length', max_line_length)
+        return errors
 
     def _error_message(self, filepath, message):
         location = Location(filepath, None, None, 0, 0)
@@ -186,7 +198,8 @@ class PylintTool(ToolBase):
         if not ext_found:
             linter.reset_options()
             self._args = linter.load_command_line_configuration(check_paths)
-            self._prospector_configure(prospector_config, linter)
+            config_messages = self._prospector_configure(
+                prospector_config, linter)
 
         # Pylint 1.4 introduced the idea of explicitly specifying which
         # C-extensions to load. This is because doing so allows them to

--- a/tests/profiles/profiles/pylint_load_plugins.yaml
+++ b/tests/profiles/profiles/pylint_load_plugins.yaml
@@ -1,0 +1,5 @@
+
+pylint:
+  load-plugins:
+    - first_plugin
+    - second_plugin

--- a/tests/profiles/test_profile.py
+++ b/tests/profiles/test_profile.py
@@ -44,6 +44,10 @@ class TestProfileParsing(ProfileTestBase):
         self.assertFalse(profile.is_tool_enabled('pylint'))
         self.assertTrue(profile.is_tool_enabled('pep8') is None)
 
+    def test_load_plugins(self):
+        profile = ProspectorProfile.load('pylint_load_plugins', self._profile_path)
+        self.assertEqual(['first_plugin', 'second_plugin'], profile.pylint['load-plugins'])
+
 
 class TestProfileInheritance(ProfileTestBase):
 


### PR DESCRIPTION
This PR relates to #315.
This is simple way to load one tool specific option (load-plugins in pylint) from profile and use it. Any thoughts on how to use specific options in profile? Because for now I haven't found anything better.