### PR TITLE
Travis CI: Drop EOLed Python 3.4 and add 3.7 and nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
-language: python
+dist: xenial  # required for Python >= 3.7
 # http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7-dev"
+  - "3.7"
+  - "nightly"
 install:
   - "pip install --editable .[build_tools]"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial  # required for Python >= 3.7
-# http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
   - "3.6"
   - "3.7"
   - "nightly"
+matrix:
+  allow_failures:
+    - python: "nightly"
 install:
   - "pip install --editable .[build_tools]"
 script:


### PR DESCRIPTION
Python 3.4 is EOL  https://devguide.python.org/devcycle/#end-of-life-branches