### PR TITLE
Pylint fix for message definitions usage

### DIFF
--- a/prospector/tools/pylint/collector.py
+++ b/prospector/tools/pylint/collector.py
@@ -29,7 +29,7 @@ class Collector(BaseReporter):
             if PYLINT_VERSION < (2, 0):
                 msg_data = self._message_store.check_message_id(msg_id)
             else:
-                msg_data = self._message_store.get_message_definition(msg_id)
+                msg_data = self._message_store.get_message_definitions(msg_id)[0]
         except UnknownMessageError:
             # this shouldn't happen, as all pylint errors should be
             # in the message store, but just in case we'll fall back


### PR DESCRIPTION
Fix to support latest pylint message definition implementation. They're now providing the result as a list, thus the implementation similar to how they're using it internally.

c/c @carlio 