### PR TITLE
Fix incompatibility issue with mypy>=0.730

### DIFF
--- a/prospector/tools/mypy/__init__.py
+++ b/prospector/tools/mypy/__init__.py
@@ -92,4 +92,10 @@ class MypyTool(ToolBase):
         result = self.checker.run(paths)
         report, _ = result[0], result[1:]  # noqa
 
-        return [format_message(message) for message in report.splitlines()]
+        formatted = []
+        for message in report.splitlines():
+            try:
+                formatted.append(format_message(message))
+             except ValueError:
+                pass
+        return formatted

--- a/prospector/tools/mypy/__init__.py
+++ b/prospector/tools/mypy/__init__.py
@@ -96,6 +96,6 @@ class MypyTool(ToolBase):
         for message in report.splitlines():
             try:
                 formatted.append(format_message(message))
-             except ValueError:
+            except ValueError:
                 pass
         return formatted


### PR DESCRIPTION
Introduce functionality to ignore formattable messages generated from mypy. This might cause possible silent failures because of the `pass` in the except block, but that can be changed.

Closes #345 