### PR TITLE
Mypy 730 compat

### DIFF
--- a/prospector/tools/mypy/__init__.py
+++ b/prospector/tools/mypy/__init__.py
@@ -89,9 +89,7 @@ class MypyTool(ToolBase):
     def run(self, found_files):
         paths = [path for path in found_files.iter_module_paths()]
         paths.extend(self.options)
-        report, _ = self.checker.run(paths)
-        messages = report.splitlines()
-        if messages and messages[-1].startswith(('Found', 'Success')):
-            del messages[-1]
+        result = self.checker.run(paths)
+        report, _ = result[0], result[1:]  # noqa
 
-        return [format_message(message) for message in messages]
+        return [format_message(message) for message in report.splitlines()]

--- a/prospector/tools/mypy/__init__.py
+++ b/prospector/tools/mypy/__init__.py
@@ -44,7 +44,7 @@ class MypyTool(ToolBase):
     def __init__(self, *args, **kwargs):
         super(MypyTool, self).__init__(*args, **kwargs)
         self.checker = api
-        self.options = ['--show-column-numbers']
+        self.options = ['--show-column-numbers', '--no-error-summary']
 
     def configure(self, prospector_config, _):
         options = prospector_config.tool_options('mypy')

--- a/tests/tools/mypy/test_mypy_tool.py
+++ b/tests/tools/mypy/test_mypy_tool.py
@@ -1,17 +1,10 @@
 # -*- coding: utf-8 -*-
-import sys
 from unittest import SkipTest, TestCase
 
 from prospector.message import Location, Message
 
-if sys.version_info >= (3, 0):
-    from unittest import mock
-else:
-    import mock
-
-
 try:
-    from prospector.tools.mypy import MypyTool, format_message
+    from prospector.tools.mypy import format_message
 except ImportError:
     raise SkipTest
 
@@ -47,47 +40,3 @@ class TestMypyTool(TestCase):
             source="mypy", code="error", location=location, message="Important error"
         )
         self.assertEqual(format_message("file.py:17: error: Important error"), expected)
-
-    def test_pre730_format(self):
-        tool = MypyTool()
-        found_files = mock.MagicMock()
-        output = ['file.py:17: error: Important error', 'file.py:17:2: error: Important error']
-
-        with mock.patch('mypy.api.run') as mock_mypy:
-            mock_mypy.return_value = ('\n'.join(output), "unused")
-            messages = tool.run(found_files)
-
-        self.assertEqual(len(messages), len(output))
-
-    def test_pre730_format_empty(self):
-        tool = MypyTool()
-        found_files = mock.MagicMock()
-        output = []
-
-        with mock.patch('mypy.api.run') as mock_mypy:
-            mock_mypy.return_value = ('\n'.join(output), "unused")
-            messages = tool.run(found_files)
-
-        self.assertEqual(len(messages), len(output))
-
-    def test_post730_format(self):
-        tool = MypyTool()
-        found_files = mock.MagicMock()
-        output = ['file.py:17: error: Important error', 'file.py:17:2: error: Important error', 'Found 2 errors in 1 file (checked 63 source files)']
-
-        with mock.patch('mypy.api.run') as mock_mypy:
-            mock_mypy.return_value = ('\n'.join(output), "unused")
-            messages = tool.run(found_files)
-
-        self.assertEqual(len(messages), len(output) - 1)
-
-    def test_post730_format_empty(self):
-        tool = MypyTool()
-        found_files = mock.MagicMock()
-        output = ['Success: no issues found in 9 source files']
-
-        with mock.patch('mypy.api.run') as mock_mypy:
-            mock_mypy.return_value = ('\n'.join(output), "unused")
-            messages = tool.run(found_files)
-
-        self.assertEqual(len(messages), len(output) - 1)


### PR DESCRIPTION
My previous patch does not work because of [this silly change](https://github.com/PyCQA/prospector/pull/349/files#diff-a8f66834285bb48ac2142c47470c885aR92) I did after testing…

Somehow, I missed the `--no-error-summary` flag the first time I read https://github.com/PyCQA/prospector/issues/345. Thanks @ziyadedher for finding this!

Therefore, this PR reverts my previous attempt and passes one more flag.

I've tested this on mypy 0.720: it correctly ignores this flag. And it works with 0.740.