### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
   - "nightly"
 matrix:
   allow_failures:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -37,7 +37,7 @@ handling the output of other tools. However, please do run them before submittin
 
     nosetests tests/
 
-Prospector targets Python 2.7, 3.3, 3.4, 3.5 and 3.6. You can use `tox`_ to test this locally,
+Prospector targets Python 2.7, 3.4, 3.5, 3.6, 3.7 and 3.8. You can use `tox`_ to test this locally,
 and all tests are run on `travis-ci.org`_.
 
 .. _tox: https://tox.readthedocs.io/en/latest/

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -37,7 +37,7 @@ handling the output of other tools. However, please do run them before submittin
 
     nosetests tests/
 
-Prospector targets Python 2.7, 3.3, 3.4, 3.5 and 3.6. You can use `tox`_ to test this locally,
+Prospector targets Python 2.7, 3.4, 3.5, 3.6, 3.7 and 3.8. You can use `tox`_ to test this locally,
 and all tests are run on `travis-ci.org`_.
 
 .. _tox: https://tox.readthedocs.io/en/latest/

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ _INSTALL_REQUIRES = [
     'dodgy>=0.1.9',
     'pyyaml',
     'mccabe>=0.5.0',
-    'pyflakes<2.1.0,>=0.8.1',
+    'pyflakes<2.2.0,>=0.8.1',
     'pycodestyle<=2.4.0,>=2.0.0',
     'pep8-naming>=0.3.3,<=0.4.1',
     'pydocstyle>=2.0.0',
@@ -34,8 +34,10 @@ _INSTALL_REQUIRES = [
 
 if sys.version_info < (3, 0):
     _INSTALL_REQUIRES += ['pylint<2', 'pylint-django<0.9']
-else:
+elif sys.version_info < (3, 5):
     _INSTALL_REQUIRES += ['pylint==2.3.1', 'pylint-django==2.0.10', 'astroid==2.2.5']
+else:
+    _INSTALL_REQUIRES += ['pylint==2.4.4', 'pylint-django==2.0.12', 'astroid==2.3.3']
 
 _PACKAGE_DATA = {
     'prospector': [
@@ -56,6 +58,7 @@ _CLASSIFIERS = [
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'License :: OSI Approved :: '
     'GNU General Public License v2 or later (GPLv2+)',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37
+envlist = py27,py34,py35,py36,py37,py38
 
 skip_missing_interpreters = true
 


### PR DESCRIPTION
This should fix failures with `pyflakes` (#353) and `pylint` when running `prospector` with Python 3.8 and marks Python 3.8 as supported by `prospector`.

## Related Issue
#353

## How Has This Been Tested?
Aside from running the included tests with Python 3.8 I ran `prospector` against a large proprietary project which had `pylint` and `pyflakes` failing previously when running with Python 3.8.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] My change requires a change to the dependencies
- [x] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.