### PR TITLE
#358 pycodestyle version support

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,6 +19,7 @@ Contributors
 * Jon Parise ([@jparise](https://github.com/jparise))
 * Kristian Glass ([@doismellburning](https://github.com/doismellburning))
 * Luke Hinds ([@lukehinds](https://github.com/lukehinds))
+* Matt Seymour ([@mattseymour](https://github.com/mattseymour))
 * Phil Frost ([@bitglue](https://github.com/bitglue))
 * Phil Jones ([@pgjones](https://github.com/pgjones))
 * SergeyKosarchuk ([@SergeyKosarchuk](https://github.com/SergeyKosarchuk))

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ _INSTALL_REQUIRES = [
     'pyyaml',
     'mccabe>=0.5.0',
     'pyflakes<2.2.0,>=0.8.1',
-    'pycodestyle<=2.4.0,>=2.0.0',
+    'pycodestyle<=2.5.0,>=2.0.0',
     'pep8-naming>=0.3.3,<=0.4.1',
     'pydocstyle>=2.0.0',
 ]


### PR DESCRIPTION
Bump the supported pycodestyle version from (<=2.4.0 to <=2.5.0). This aids in supporting flake8 (and other tools) which requires pycodestyle version 2.5.0. 

## Description
Update setup.py requirements

## Related Issue
Issue #358 

## Motivation and Context
Without this change, it is not possible to install flake8 and prospector in the same environment without a dependency clash.

## How Has This Been Tested?
* Ran test set as well as poetry install using flake8 and prospector

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change requires a change to the dependencies
- [x] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
