### PR TITLE
Fix simple typo: supress -> suppress

### DIFF
--- a/prospector/tools/pylint/linter.py
+++ b/prospector/tools/pylint/linter.py
@@ -33,7 +33,7 @@ class ProspectorLinter(PyLinter):  # pylint: disable=too-many-ancestors,too-many
 
     def reset_options(self):
         # for example, we want to re-initialise the OptionsManagerMixin
-        # to supress the config error warning
+        # to suppress the config error warning
         # pylint: disable=non-parent-init-called
         if PYLINT_VERSION >= (2, 0):
             OptionsManagerMixIn.__init__(self, usage=PyLinter.__doc__)


### PR DESCRIPTION
Simple typo in prospector/tools/pylint/linter.py 

## Description
Should read suppress rather than supress.

## Related Issue
Closes #360 

## Motivation and Context
Resolves a typo

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
