### PR TITLE
Adding output-target field when merging profiles

### DIFF
--- a/prospector/profiles/profile.py
+++ b/prospector/profiles/profile.py
@@ -203,7 +203,7 @@ def _merge_profile_dict(priority, base):
             # some keys are simple values which are overwritten
             out[key] = value
         elif key in ('ignore', 'ignore-patterns', 'ignore-paths', 'uses',
-                     'requirements', 'python-targets'):
+                     'requirements', 'python-targets','output-target',):
             # some keys should be appended
             out[key] = _ensure_list(value) + _ensure_list(base.get(key, []))
         elif key in TOOLS.keys():

--- a/prospector/tools/profile_validator/__init__.py
+++ b/prospector/tools/profile_validator/__init__.py
@@ -26,7 +26,7 @@ class ProfileValidationTool(ToolBase):
     )
     ALL_SETTINGS = LIST_SETTINGS + (
         'strictness', 'autodetect', 'max-line-length',
-        'output-format', 'doc-warnings', 'test-warnings', 'member-warnings',
+        'output-format', 'output-target', 'doc-warnings', 'test-warnings', 'member-warnings',
         # bit of a grim hack; prospector does not use the following but Landscape does:
         # TODO: think of a better way to avoid Landscape-specific config leaking into prospector
         'requirements', 'python-targets',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes how the output-target field defined in the configuration is used by prospector . Without this, the field is overwritten during profile dictionary merge and never used even if specified by the user.

## Related Issue
This is one of the steps to achieve resolution of #[377](https://github.com/PyCQA/prospector/issues/377)

## Motivation and Context
Based on the [profile.py](https://github.com/PyCQA/prospector/blob/master/prospector/profiles/profile.py#L49), there is a profile item that people can use to output the prospector results into a target directory/file.

## How Has This Been Tested?
I've been doing this in a project at the company I work to have the prospector's results in a reports directory.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [ ] I have updated the dependencies accordingly
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
