### PR TITLE
Update pylint and ignore error from removed rule

### DIFF
--- a/prospector/tools/pylint/__init__.py
+++ b/prospector/tools/pylint/__init__.py
@@ -79,7 +79,7 @@ class PylintTool(ToolBase):
         # allow the indentation specified in the pylint configuration file; we
         # replace it instead with our own version which is more lenient and
         # configurable
-        linter.disable("mixed-indentation")
+        linter.disable("mixed-indentation", ignore_unknown=True)
         indent_checker = IndentChecker(linter)
         linter.register_checker(indent_checker)
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ _INSTALL_REQUIRES = [
     "pycodestyle<2.7.0,>=2.6.0",
     "pep8-naming>=0.3.3,<=0.10.0",
     "pydocstyle>=2.0.0",
-    "pylint==2.5.3",
+    "pylint==2.6.2",
     "pylint-django<2.2.0",
     "astroid==2.4.1",
 ]


### PR DESCRIPTION
Pylint 2.6.1 contains security fix for [a vulnerability](https://snyk.io/vuln/SNYK-PYTHON-PYLINT-609883). 


## Description
This change ignores `UnknownMessageError` to support running on other versions of pylint.

## Motivation and Context

At the moment prospector cannot run checks with the pylint 2.6.1+ due to the error:

```python
  File "/Users/eoskin/projects/prospector/tests/tools/pylint/test_pylint_tool.py", line 36, in test_wont_throw_false_positive_relative_beyond_top_level                                                                                                                                             
    pylint_tool.configure(config, found_files)                                                                                                                                                                                                                                                      
  File "/Users/eoskin/projects/prospector/prospector/tools/pylint/__init__.py", line 128, in configure                                                                                                                                                                                              
    check_paths, config_messages, configured_by, ext_found, linter, prospector_config, pylint_options                                             
  File "/Users/eoskin/projects/prospector/prospector/tools/pylint/__init__.py", line 218, in _get_pylint_configuration                                                                                                                                                                              
    config_messages = self._prospector_configure(prospector_config, linter)                                                                                                                                                                                                                         
  File "/Users/eoskin/projects/prospector/prospector/tools/pylint/__init__.py", line 82, in _prospector_configure                                                                                                                                                                                   
    linter.disable("mixed-indentation")                            
  File "/Users/eoskin/projects/prospector/.tox/py36/lib/python3.6/site-packages/pylint/message/message_handler_mix_in.py", line 68, in disable    
    msgid, enable=False, scope=scope, line=line, ignore_unknown=ignore_unknown                                                                    
  File "/Users/eoskin/projects/prospector/.tox/py36/lib/python3.6/site-packages/pylint/message/message_handler_mix_in.py", line 118, in _set_msg_status                                                                                                                                             
    message_definitions = self.msgs_store.get_message_definitions(msgid)                                                                                                                                                                                                                            
  File "/Users/eoskin/projects/prospector/.tox/py36/lib/python3.6/site-packages/pylint/message/message_definition_store.py", line 57, in get_message_definitions                                                                                                                                    
    for m in self.message_id_store.get_active_msgids(msgid_or_symbol)                                                                                                                                                                                                                               
  File "/Users/eoskin/projects/prospector/.tox/py36/lib/python3.6/site-packages/pylint/message/message_id_store.py", line 120, in get_active_msgids                                                                                                                                                 
    raise UnknownMessageError(error_msg)                                                                                                          
pylint.exceptions.UnknownMessageError: No such message id or symbol 'mixed-indentation'.         
```

`mixed-indentation` was removed [pylint 2.6.1](http://pylint.pycqa.org/en/latest/whatsnew/2.6.html?highlight=mixed-indentation#other-changes).

## How Has This Been Tested?

I've tested the change by running it on the prospector code base and by running tox on macOS 11.2.1.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change requires a change to the dependencies
- [x] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
