### PR TITLE
Fix filenames if they are PosixPath

### DIFF
--- a/prospector/formatters/grouped.py
+++ b/prospector/formatters/grouped.py
@@ -21,7 +21,7 @@ class GroupedFormatter(TextFormatter):
             groups[message.location.path][message.location.line].append(message)
 
         for filename in sorted(groups.keys()):
-            output.append(filename)
+            output.append("%s" % filename)
 
             for line in sorted(groups[filename].keys(), key=lambda x: 0 if x is None else int(x)):
                 output.append("  Line: %s" % line)

--- a/prospector/formatters/json.py
+++ b/prospector/formatters/json.py
@@ -29,6 +29,9 @@ class JsonFormatter(Formatter):
         if profile:
             output["profile"] = self.profile.as_dict()
 
+        for message in self.messages:
+            if not isinstance(message.location.path, str):
+                message.location.path=str(message.location.path)
         if messages:
             output["messages"] = [m.as_dict() for m in self.messages]
 


### PR DESCRIPTION
## Description
When prospector is used with Vulture, filenames are PosixPath and cannot be merged in Json

## Related Issue
https://github.com/PyCQA/prospector/issues/404
