### PR TITLE
Update to support newer versions of pylint (w/ backwards compatibility)

### DIFF
--- a/prospector/tools/pylint/__init__.py
+++ b/prospector/tools/pylint/__init__.py
@@ -79,7 +79,7 @@ class PylintTool(ToolBase):
         # allow the indentation specified in the pylint configuration file; we
         # replace it instead with our own version which is more lenient and
         # configurable
-        linter.disable("mixed-indentation")
+        linter.disable("mixed-indentation", ignore_unknown=True)
         indent_checker = IndentChecker(linter)
         linter.register_checker(indent_checker)
 

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,9 @@ _INSTALL_REQUIRES = [
     "pycodestyle<2.7.0,>=2.6.0",
     "pep8-naming>=0.3.3,<=0.10.0",
     "pydocstyle>=2.0.0",
-    "pylint==2.5.3",
+    "pylint>=2.5.3,<2.9",
     "pylint-django<2.2.0",
-    "astroid==2.4.1",
+    "astroid", # Pinned to the pylint version
 ]
 
 


### PR DESCRIPTION
Recent versions of pylint have several useful features. It seems like these should be leveraged in prospector.

## Description
Push the underlying pylint version to 2.8 from 2.5 (though the pinning is still pretty bad, since a wider number of pylint versions should be compatible (anything >= 2.5)

## Related Issue
Related to issues #406 #409 #418 

## Motivation and Context
New features of pylint are useful, and should be incorporated. Further, the version should be largely backwards compatible, so should not be pinned so tightly. 

## How Has This Been Tested?
Ran the included testing, as well as on a large (50k LOC) project. Passes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- (N/A) My change requires a change to the documentation.
- (N/A) I have updated the documentation accordingly.
- [x] My change requires a change to the dependencies
- [x] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- (N/A) I have added tests to cover my changes.
- [x] All new and existing tests passed.
