### PR TITLE
Prohibit downloading via pip if the python interpreter is too old

### DIFF
--- a/prospector/formatters/json.py
+++ b/prospector/formatters/json.py
@@ -31,7 +31,7 @@ class JsonFormatter(Formatter):
 
         for message in self.messages:
             if not isinstance(message.location.path, str):
-                message.location.path=str(message.location.path)
+                message.location.path = str(message.location.path)
         if messages:
             output["messages"] = [m.as_dict() for m in self.messages]
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 # pylint: skip-file
 import codecs
 import os
-import sys
 from distutils.core import setup
 
 from setuptools import find_packages
@@ -10,10 +9,6 @@ from setuptools import find_packages
 with open("prospector/__pkginfo__.py") as f:
     exec(f.read())
 _VERSION = globals()["__version__"]
-
-if sys.version_info < (3, 6):
-    raise Exception("Prospector %s requires Python 3.6 or higher." % _VERSION)
-
 
 _PACKAGES = find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
 
@@ -53,6 +48,7 @@ _CLASSIFIERS = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "License :: OSI Approved :: " "GNU General Public License v2 or later (GPLv2+)",
 ]
 
@@ -97,4 +93,5 @@ setup(
     },
     install_requires=_INSTALL_REQUIRES,
     extras_require=_OPTIONAL,
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This will permit for the package to not be downloaded in the first place if the interpreter is too old.

## Related Issue
 https://github.com/PyCQA/prospector/pull/432
