### PR TITLE
Bump isort version to support Python 3.10

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -513,7 +513,7 @@ python-versions = ">=3.6.2"
 [package.dependencies]
 astroid = ">=2.9.0,<2.10"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-isort = ">=4.2.5,<6"
+isort = ">=4.3.5,<6"
 mccabe = ">=0.6,<0.7"
 platformdirs = ">=2.2.0"
 toml = ">=0.9.2"


### PR DESCRIPTION
https://github.com/PyCQA/isort/issues/756
Deprecated `MutableSet` (re)moved from `collections` in Python 3.10.

<details><summary>
Prospector stacktrace
</summary>

```
Traceback (most recent call last):
  File "/home/u/.local/bin/prospector", line 5, in <module>
    from prospector.run import main
  File "/home/u/.local/lib/python3.10/site-packages/prospector/run.py", line 7, in <module>
    from prospector import blender, postfilter, tools
  File "/home/u/.local/lib/python3.10/site-packages/prospector/tools/__init__.py", line 9, in <module>
    from prospector.tools.pylint import PylintTool
  File "/home/u/.local/lib/python3.10/site-packages/prospector/tools/pylint/__init__.py", line 8, in <module>
    from prospector.tools.pylint.collector import Collector
  File "/home/u/.local/lib/python3.10/site-packages/prospector/tools/pylint/collector.py", line 5, in <module>
    from pylint.reporters import BaseReporter
  File "/home/u/.local/lib/python3.10/site-packages/pylint/reporters/__init__.py", line 27, in <module>
    from pylint import utils
  File "/home/u/.local/lib/python3.10/site-packages/pylint/utils/__init__.py", line 48, in <module>
    from pylint.utils.docs import print_full_documentation
  File "/home/u/.local/lib/python3.10/site-packages/pylint/utils/docs.py", line 9, in <module>
    from pylint.utils.utils import get_rst_section, get_rst_title
  File "/home/u/.local/lib/python3.10/site-packages/pylint/utils/utils.py", line 6, in <module>
    import isort.api
  File "/usr/lib/python3/dist-packages/isort/__init__.py", line 25, in <module>
    from . import settings  # noqa: F401
  File "/usr/lib/python3/dist-packages/isort/settings.py", line 34, in <module>
    from .pie_slice import itemsview, lru_cache, native_str
  File "/usr/lib/python3/dist-packages/isort/pie_slice.py", line 362, in <module>
    class OrderedSet(collections.MutableSet):
AttributeError: module 'collections' has no attribute 'MutableSet'
```

</details>