### PR TITLE
Re-add `__main__.py` to enable executing as a module

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -7,7 +7,7 @@ All contributions are very welcome! You can contribute in many ways:
 
 * Report bugs on the GitHub `issue tracker`_.
 
-* Submit pull requests on the GitHub `repository`_. Ideally make a pull request to the *develop* branch, as I prefer to keep the master branch the same as the most recent release on PyPI. If you do this, be sure to add yourself to the CONTRIBUTORS.md file too!
+* Submit pull requests on the GitHub `repository`_. Ideally make a pull request to the *develop* branch, as I prefer to keep the master branch the same as the most recent release on PyPI. If you do this, be sure to add yourself to the CONTRIBUTORS.rst file too!
 
 .. _python code quality: https://mail.python.org/mailman/listinfo/code-quality
 .. _issue tracker: https://github.com/PyCQA/prospector/issues

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -23,6 +23,7 @@ Contributors
 * Kristian Glass (`@doismellburning <https://github.com/doismellburning>`_)
 * Luke Hinds (`@lukehinds <https://github.com/lukehinds>`_)
 * Matt Seymour (`@mattseymour <https://github.com/mattseymour>`_)
+* Michael Tinsley (`@michaeltinsley <https://github.com/michaeltinsley>`_)
 * Phil Frost (`@bitglue <https://github.com/bitglue>`_)
 * Phil Jones (`@pgjones <https://github.com/pgjones>`_)
 * Pierre Sassoulas (`@Pierre-Sassoulas <https://github.com/Pierre-Sassoulas>`_)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -20,6 +20,9 @@ And you can specify a list of python modules::
 
 See below for :ref:`a complete list of options and flags<full_options>`. You can also run ``prospector --help`` for a full list of options and their effects.
 
+Alternatively, prospector can be executed as a module::
+
+    python3 -m prospector <args>
 
 Output Format
 '''''''''''''

--- a/prospector/__main__.py
+++ b/prospector/__main__.py
@@ -1,0 +1,6 @@
+import sys
+
+from prospector.run import main
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Re-adds `__main__.py` to enable executing as a module.
This was added in 0.12.6, and removed in 1.7.3.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #496 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

With this, prospector paths don't need to be added. 
In my experience, it also make integration with CI easier.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [ ] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
