### PR TITLE
docs: fix simple typo, compatile -> compatible

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -50,7 +50,7 @@ The default output format of ``prospector`` is designed to be human readable. Yo
 +-------------+----------------------------------------------------------------------------+
 | ``yaml``    | | Same as JSON except produces YAML output.                                |
 +-------------+----------------------------------------------------------------------------+
-| ``xunit``   | | Same as JSON except produces xunit compatile XML output.                 |
+| ``xunit``   | | Same as JSON except produces xunit compatible XML output.                 |
 +-------------+----------------------------------------------------------------------------+
 | ``text``    | | The default output format, a simple human readable format.               |
 +-------------+----------------------------------------------------------------------------+


### PR DESCRIPTION
There is a small typo in docs/usage.rst.

Should read `compatible` rather than `compatile`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md