### PR TITLE
Use StringIO in the pylint collector instead of sys.stdout

### DIFF
--- a/prospector/tools/pylint/collector.py
+++ b/prospector/tools/pylint/collector.py
@@ -1,3 +1,4 @@
+from io import StringIO
 from typing import List, Tuple, Union
 
 from pylint.exceptions import UnknownMessageError
@@ -12,7 +13,7 @@ class Collector(BaseReporter):
     name = "collector"
 
     def __init__(self, message_store):
-        BaseReporter.__init__(self, output=None)
+        BaseReporter.__init__(self, output=StringIO())
         self._message_store = message_store
         self._messages = []
 


### PR DESCRIPTION
## Description

By not setting an explicit output for the collector, pylint defaults to stdout, which then fails to serialize by dill in a multi-process execution environment. This change sets an explicit instance of StringIO for the output stream.

## Related Issue

Closes #513 

## Motivation and Context

This is just a guess, but I'm not familiar enough with the full context of what the `out` attribute in a pylint reporter does, how it's used, and whether it matters that we just disregard its contents.

## How Has This Been Tested?

Tested by applying this change to the 1.7.7 release, and running with pylint 2.15.5, with `jobs: 0` enabled for the pylint tool in `.prospector.yml`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [ ] I have updated the dependencies accordingly
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
