### PR TITLE
Update types in ProspectorLinter

### DIFF
--- a/prospector/tools/pylint/linter.py
+++ b/prospector/tools/pylint/linter.py
@@ -1,5 +1,6 @@
 from pylint.lint import PyLinter
 from pylint.utils import _splitstrip
+from pylint import version as pylint_version
 
 
 class ProspectorLinter(PyLinter):
@@ -19,8 +20,15 @@ class ProspectorLinter(PyLinter):
 
     def _expand_files(self, modules):
         expanded = super()._expand_files(modules)
-        filtered = {}
-        for filepath, module in expanded.items():
-            if self._files.check_module(module["path"]):
-                filtered[filepath] = module
+        # PyLinter._expand_files returns dict since 2.15.7.
+        if pylint_version > "2.15.6":
+            filtered = {}
+            for module in expanded:
+                if self._files.check_module(module):
+                    filtered[module] = expanded[module]
+        else:
+            filtered = []
+            for module in expanded:
+                if self._files.check_module(module["path"]):
+                    filtered.append(module)
         return filtered

--- a/prospector/tools/pylint/linter.py
+++ b/prospector/tools/pylint/linter.py
@@ -19,8 +19,8 @@ class ProspectorLinter(PyLinter):
 
     def _expand_files(self, modules):
         expanded = super()._expand_files(modules)
-        filtered = []
-        for module in expanded:
+        filtered = {}
+        for filepath, module in expanded.items():
             if self._files.check_module(module["path"]):
-                filtered.append(module)
+                filtered[filepath] = module
         return filtered

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ prospector = 'prospector.run:main'
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
-pylint = ">=2.8.3"
+pylint = ">=2.15.7"
 pylint-celery = "0.3"
 pylint-django = "~2.5"
 pylint-plugin-utils = "~0.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ prospector = 'prospector.run:main'
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
-pylint = ">=2.15.7"
+pylint = ">=2.8.3"
 pylint-celery = "0.3"
 pylint-django = "~2.5"
 pylint-plugin-utils = "~0.7"


### PR DESCRIPTION
## Description
pylint 2.15.7 changes `PyLinter._expand_files` to return `dict[str, ModuleDescriptionDict]` instead of `list[ModuleDescriptionDict]`. This PR changes `ProspectorLinter._expand_files` accordingly.

## Related Issue
Closes #529

## Motivation and Context
Prospector currently cannot run pylint.

## How Has This Been Tested?
I've verified that prospector can run pylint with this change applied.

I've run `pytest`locally. All tests fail, but they do that in master, too.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [ ] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
