### PR TITLE
Add prettier in pre-commit configuration for markdown files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,30 +3,27 @@ name: Bug report
 about: Create a report to help us improve
 title: "[BUG]"
 labels: investigate
-assignees: ''
-
+assignees: ""
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**Describe the bug** A clear and concise description of what the bug is.
 
-**To Reproduce**
-Steps to reproduce the behavior:
+**To Reproduce** Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Call prospector the following way '....'
 3. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+**Expected behavior** A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Screenshots** If applicable, add screenshots to help explain your problem.
 
 **Environment (please complete the following information):**
- - OS: [e.g. macOS]
- - Tool [e.g. pylint]
- - Prospector version [e.g. 1.1.7]
+
+- OS: [e.g. macOS]
+- Tool [e.g. pylint]
+- Prospector version [e.g. 1.1.7]
 - Python version [e.g. 3.6.8]
 
-**Additional context**
-Add any other context about the problem here. Putting the list of dependencies installed, e.g. the output of `pip freeze` also helps.
+**Additional context** Add any other context about the problem here. Putting the list of
+dependencies installed, e.g. the output of `pip freeze` also helps.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,18 +3,17 @@ name: Feature request
 about: Suggest an idea for this project
 title: "[FEATURE REQUEST]"
 labels: enhancement
-assignees: ''
-
+assignees: ""
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**Is your feature request related to a problem? Please describe.** A clear and concise
+description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+**Describe the solution you'd like** A clear and concise description of what you want to
+happen.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Describe alternatives you've considered** A clear and concise description of any
+alternative solutions or features you've considered.
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+**Additional context** Add any other context or screenshots about the feature request
+here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,31 +1,39 @@
 <!--- Provide a general summary of your changes in the Title above -->
 
 ## Description
+
 <!--- Describe your changes in detail -->
 
 ## Related Issue
+
 <!--- This project only accepts pull requests related to open issues -->
 <!--- If suggesting a new feature or change, please discuss it in an issue first -->
 <!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
 <!--- Please link to the issue here: -->
 
 ## Motivation and Context
+
 <!--- Why is this change required? What problem does it solve? -->
 
 ## How Has This Been Tested?
+
 <!--- Please describe in detail how you tested your changes. -->
 <!--- Include details of your testing environment, and the tests you ran to -->
 <!--- see how your change affects other areas of the code, etc. -->
 
 ## Types of changes
+
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
 ## Checklist:
+
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
 - [ ] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,45 +1,52 @@
 fail_fast: true
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: mixed-line-ending
-        args: [ --fix=lf ]
-    -   id: debug-statements
-    -   id: check-added-large-files
--   repo: https://github.com/psf/black
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: debug-statements
+      - id: check-added-large-files
+  - repo: https://github.com/psf/black
     rev: 22.10.0
     hooks:
-    -   id: black
+      - id: black
         args:
-            - --exclude=/(tests)/
-            - --line-length=120
--   repo: https://github.com/codespell-project/codespell
+          - --exclude=/(tests)/
+          - --line-length=120
+  - repo: https://github.com/codespell-project/codespell
     rev: v2.2.2
     hooks:
       - id: codespell
         args:
-            - --ignore-words-list=nin
-            - --skip=poetry.lock
--   repo: https://github.com/PyCQA/prospector
+          - --ignore-words-list=nin
+          - --skip=poetry.lock
+  - repo: https://github.com/PyCQA/prospector
     rev: v1.8.0rc3
     hooks:
-    -       id: prospector
-            additional_dependencies:
-                - "prospector[with_mypy]"
-            args:
-                - --summary-only
-                - --zero-exit
--   repo: https://github.com/PyCQA/flake8
+      - id: prospector
+        additional_dependencies:
+          - "prospector[with_mypy]"
+        args:
+          - --summary-only
+          - --zero-exit
+  - repo: https://github.com/PyCQA/flake8
     rev: 6.0.0
     hooks:
-    -   id: flake8
+      - id: flake8
         args:
-        -    --max-line-length=120
--   repo: https://github.com/PyCQA/isort
+          - --max-line-length=120
+  - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:
-    -   id: isort
+      - id: isort
         args: ["--profile", "black", "--filter-files"]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.0-alpha.0
+    hooks:
+      - id: prettier
+        files: ".pre-commit-config.yaml|.md"
+        args: [--prose-wrap=always, --print-width=88]
+        exclude: tests(/\w*)*data/

--- a/prospector/tools/pylint/linter.py
+++ b/prospector/tools/pylint/linter.py
@@ -1,6 +1,6 @@
+from pylint import version as pylint_version
 from pylint.lint import PyLinter
 from pylint.utils import _splitstrip
-from pylint import version as pylint_version
 
 
 class ProspectorLinter(PyLinter):


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Add prettier in pre-commit configuration for markdown files and the pre-commit configuration itself. This will avoid conflicts when rebasing by standardizing the code. Not applied on yaml because there's a lot of change.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [ ] I have updated the dependencies accordingly
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
