### PR TITLE
run: fix missing parameter to exception

### DIFF
--- a/prospector/run.py
+++ b/prospector/run.py
@@ -109,13 +109,13 @@ class Prospector:
 
             except Exception as ex:  # pylint:disable=broad-except
                 if self.config.die_on_tool_error:
-                    raise FatalProspectorException from ex
+                    raise FatalProspectorException(f"Tool {toolname} failed to run.") from ex
 
-                loc = Location(self.config.workdir, None, None, None, None)
                 msg = (
                     f"Tool {toolname} failed to run "
                     f"(exception was raised, re-run prospector with -X to see the stacktrace)"
                 )
+                loc = Location(self.config.workdir, None, None, None, None)
                 message = Message(
                     toolname,
                     "failure",

--- a/prospector/run.py
+++ b/prospector/run.py
@@ -111,11 +111,11 @@ class Prospector:
                 if self.config.die_on_tool_error:
                     raise FatalProspectorException(f"Tool {toolname} failed to run.") from ex
 
+                loc = Location(self.config.workdir, None, None, None, None)
                 msg = (
                     f"Tool {toolname} failed to run "
                     f"(exception was raised, re-run prospector with -X to see the stacktrace)"
                 )
-                loc = Location(self.config.workdir, None, None, None, None)
                 message = Message(
                     toolname,
                     "failure",


### PR DESCRIPTION
We were missing the message parameter when re-raising the exception
when a tool raises.



<!--- Provide a general summary of your changes in the Title above -->

## Description

When a tool failed, we are failing to pass the `message` parameter when re-raising, and that causes a chained exception
to happen:

```
Traceback (most recent call last):
  File "/home/dcaro/Work/wikimedia/operations-cookbooks/.tox/py3-prospector/lib/python3.10/site-packages/prospector/run.py", line 95, in execute
    messages += tool.run(found_files)
  File "/home/dcaro/Work/wikimedia/operations-cookbooks/.tox/py3-prospector/lib/python3.10/site-packages/prospector/tools/pylint/__init__.py", line 253, in run
    self._linter.check(self._args)
  File "/home/dcaro/Work/wikimedia/operations-cookbooks/.tox/py3-prospector/lib/python3.10/site-packages/pylint/lint/pylinter.py", line 696, in check
    ast_per_fileitem = self._get_asts(fileitems, data)
  File "/home/dcaro/Work/wikimedia/operations-cookbooks/.tox/py3-prospector/lib/python3.10/site-packages/pylint/lint/pylinter.py", line 707, in _get_asts
    for fileitem in fileitems:
  File "/home/dcaro/Work/wikimedia/operations-cookbooks/.tox/py3-prospector/lib/python3.10/site-packages/pylint/lint/pylinter.py", line 874, in _iterate_file_descrs
    for descr in self._expand_files(files_or_modules).values():
  File "/home/dcaro/Work/wikimedia/operations-cookbooks/.tox/py3-prospector/lib/python3.10/site-packages/prospector/tools/pylint/linter.py", line 24, in _expand_files
    if self._files.check_module(module["path"]):
TypeError: string indices must be integers

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/dcaro/Work/wikimedia/operations-cookbooks/.tox/py3-prospector/bin/prospector", line 8, in <module>
    sys.exit(main())
  File "/home/dcaro/Work/wikimedia/operations-cookbooks/.tox/py3-prospector/lib/python3.10/site-packages/prospector/run.py", line 203, in main
    prospector.execute()
  File "/home/dcaro/Work/wikimedia/operations-cookbooks/.tox/py3-prospector/lib/python3.10/site-packages/prospector/run.py", line 113, in execute
    raise FatalProspectorException from ex
TypeError: FatalProspectorException.__init__() missing 1 required positional argument: 'message'
```

## Related Issue

Fixes #537

## Motivation and Context

Easy fix for small misbehavior.

## How Has This Been Tested?

Ran the same command seeing now that the exception is the correct one.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [ ] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.