### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,18 @@
 name: tests
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - run: pipx install poetry

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog
 #########
 
+Version 1.8.1
+-------------
+
+Let's test faster.
+
+**Add support for Python 3.11**:
+
+Python 3.11 is between 10-60% faster than Python 3.10.
+
+
 Version 1.8.0
 -------------
 

--- a/prospector/config/__init__.py
+++ b/prospector/config/__init__.py
@@ -41,7 +41,7 @@ class ProspectorConfig:
                 # first figure out where the path is, relative to the workdir
                 # ignore-paths/patterns will usually be relative to a repository
                 # root or the CWD, but the path passed to prospector may not be
-                path = path.absolute()
+                path = path.resolve().absolute()
                 if is_relative_to(path, self.workdir):
                     path = path.relative_to(self.workdir)
                 if ignore.match(str(path)):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "prospector"
-version = "1.8.0"
+version = "1.8.1"
 description = ""
 authors = ["Carl Crowder <git@carlcrowder.com>"]
 maintainers = ["Carl Crowder <git@carlcrowder.com>",
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
 ]
 packages = [

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,7 +23,7 @@ def patch_cwd(set_cwd: Path):
     ):
         # Turns out that Python 3.10 added the `getcwd` to the _NormalAccessor instead of falling
         # back on os.getcwd, and so this needs to be patched too...
-        if sys.version_info >= (3, 10):
+        if sys.version_info[:2] == (3, 10):
             # sigh...
             with patch("pathlib._NormalAccessor.getcwd", new=lambda _: cwd_str):
                 yield


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

@Pierre-Sassoulas @carlio 
Some magic was done for `pathlib` in Python 3.10 but it seems to no longer be needed in Python 3.11.


## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [ ] I have updated the dependencies accordingly
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
