### PR TITLE
Fix merge issue with file finding (fix #547)

### DIFF
--- a/prospector/tools/pylint/linter.py
+++ b/prospector/tools/pylint/linter.py
@@ -22,15 +22,14 @@ class ProspectorLinter(PyLinter):
 
     def _expand_files(self, modules):
         expanded = super()._expand_files(modules)
+        filtered = {}
         # PyLinter._expand_files returns dict since 2.15.7.
         if pylint_version > "2.15.6":
-            filtered = {}
             for module in expanded:
-                if self._files.check_module(module):
+                if not self._files.is_excluded(Path(module)):
                     filtered[module] = expanded[module]
             return filtered
         else:
-            filtered = {}
             for module in expanded:
                 # need to de-duplicate, as pylint also walks directories given to it, so it will find
                 # files that prospector has already provided and end up checking it more than once


### PR DESCRIPTION
## Description

d5f2650960a75dbffeca705d1a7fc881fcce8a60 changed the file finding mechanism, this got lost when develop was merged.

## Related Issue

#547

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Tested manually that the error no longer occurs, also ran pytest and pre-commit. pre-commit passes, one test fails (test_total_errors). The test fails on master, too.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [ ] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
