### PR TITLE
allow packaging >=22.0,<23.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ mypy = {version = ">=0.600", optional = true}
 pyroma = {version = ">=2.4", optional = true}
 setoptconf-tmp = "^0.3.1"
 GitPython = "^3.1.27"
-packaging = ">=21.0,<23.0"
+packaging = "*"
 
 [tool.poetry.extras]
 with_bandit = ["bandit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ mypy = {version = ">=0.600", optional = true}
 pyroma = {version = ">=2.4", optional = true}
 setoptconf-tmp = "^0.3.1"
 GitPython = "^3.1.27"
-packaging = "<23.0"
+packaging = ">=21.0,<23.0"
 
 [tool.poetry.extras]
 with_bandit = ["bandit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ mypy = {version = ">=0.600", optional = true}
 pyroma = {version = ">=2.4", optional = true}
 setoptconf-tmp = "^0.3.1"
 GitPython = "^3.1.27"
-packaging = "<22.0"
+packaging = "<23.0"
 
 [tool.poetry.extras]
 with_bandit = ["bandit"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Loosen dependency on packaging from 22.0 to <23.0

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change will allow prospector to be installed alongside other common tools (e.g. black) use packaging >22.0.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This change was tested by running the pre-commit hooks and CI workflow.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change requires a change to the dependencies
- [x] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
