### PR TITLE
Be able to load a profile from an external package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,8 @@ jobs:
       # - run: poetry show --all
       # - run: poetry show --outdated
       # - run: poetry show --tree
+      - name: Install test profile used in the tests
+        run: poetry run pip install tests/prospector-profile-test/
       - run: poetry run pytest --benchmark-disable --cov --cov-report= tests/
       - name: Check that Prospector can run
         run: |

--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -235,6 +235,15 @@ built-in prospector profiles::
     inherits:
         - strictness_medium
 
+The ``inherits`` file can also be in an external package, if you specify a name Prospector will search for a tile named
+``prospector.yaml`` or ``prospector.yml`` in the module ``prospector-profile-<name>``. And if the name contains a ``:``
+this mean that we use the syntax ``<module>:<file>`` to search the file named ``<file>.yaml`` or ``<file>.yml``
+in the module name ``prospector-profile-<module>``. For example::
+
+    inherits:
+        - my_module
+        - my_module:my_file
+
 .. _ignore-paths:
 .. _ignore-patterns:
 

--- a/prospector/config/__init__.py
+++ b/prospector/config/__init__.py
@@ -195,9 +195,13 @@ class ProspectorConfig:
             )
             sys.exit(1)
         except ProfileNotFound as nfe:
+            search_path = ":".join(map(str, nfe.profile_path))
+            profile = nfe.name.split(":")[0]
             sys.stderr.write(
-                "Failed to run:\nCould not find profile %s. Search path: %s\n"
-                % (nfe.name, ":".join(map(str, nfe.profile_path)))
+                f"""Failed to run:
+Could not find profile {nfe.name}.
+Search path: {search_path}, or in module 'prospector_profile_{profile}'
+"""
             )
             sys.exit(1)
         else:

--- a/tests/profiles/profiles/inherittest-module-file.yaml
+++ b/tests/profiles/profiles/inherittest-module-file.yaml
@@ -1,0 +1,2 @@
+inherits:
+  - test:alternate

--- a/tests/profiles/profiles/inherittest-module.yaml
+++ b/tests/profiles/profiles/inherittest-module.yaml
@@ -1,0 +1,2 @@
+inherits:
+  - test

--- a/tests/profiles/test_profile.py
+++ b/tests/profiles/test_profile.py
@@ -198,3 +198,11 @@ class TestProfileInheritance(ProfileTestBase):
     def test_pycodestyle_inheritance(self):
         profile = self._load("pep8")
         self.assertTrue("full_pep8" in profile.inherit_order)
+
+    def test_module_inheritance(self):
+        profile = ProspectorProfile.load("inherittest-module", self._profile_path, allow_shorthand=False)
+        self.assertEqual(["test-from-module"], profile.pylint["disable"])
+
+    def test_module_file_inheritance(self):
+        profile = ProspectorProfile.load("inherittest-module-file", self._profile_path, allow_shorthand=False)
+        self.assertEqual(["alternate-test-from-module"], profile.pylint["disable"])

--- a/tests/prospector-profile-test/prospector_profile_test/alternate.yaml
+++ b/tests/prospector-profile-test/prospector_profile_test/alternate.yaml
@@ -1,0 +1,3 @@
+pylint:
+  disable:
+    - alternate-test-from-module

--- a/tests/prospector-profile-test/prospector_profile_test/prospector.yaml
+++ b/tests/prospector-profile-test/prospector_profile_test/prospector.yaml
@@ -1,0 +1,3 @@
+pylint:
+  disable:
+    - test-from-module

--- a/tests/prospector-profile-test/pyproject.toml
+++ b/tests/prospector-profile-test/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "prospector-profile-test"
+description = "A package used to test the prospector external profile"
+version = "0.0.0"
+
+[tool.setuptools.package-data]
+prospector_profile_test = ["*.yaml"]


### PR DESCRIPTION
## Description

Add the possibility to use a profile shared throw a Python package.

## Related Issue

Fix #459.

## Motivation and Context

Be able to share a profile between different projects.

## How Has This Been Tested?

- I create a package with a profile (https://github.com/sbrunner/prospector-profile-duplicated)
- I created a `.prospector.yaml`configuration file that uses this profile
- Verify that we have:
  - The default configuration
  - The profile configuration (new)
  - The project configuration (from `.prospector.yaml` file)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [ ] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
