### PR TITLE
Add use-dmypy option to MypyTool

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -22,6 +22,7 @@ Contributors
 * Joe Wallis (`@Peilonrayz <https://github.com/Peilonrayz>`_)
 * Jon Parise (`@jparise <https://github.com/jparise>`_)
 * Kristian Glass (`@doismellburning <https://github.com/doismellburning>`_)
+* Lukasz Piatkowski (`@lukaspiatkowski <https://github.com/lukaspiatkowski>`_)
 * Luke Hinds (`@lukehinds <https://github.com/lukehinds>`_)
 * Matt Seymour (`@mattseymour <https://github.com/mattseymour>`_)
 * Michael Tinsley (`@michaeltinsley <https://github.com/michaeltinsley>`_)

--- a/docs/profiles.rst
+++ b/docs/profiles.rst
@@ -394,6 +394,9 @@ The available options are:
 +----------------+------------------------+----------------------------------------------+
 | mypy           | namespace-packages     | Import discovery uses namespace packages     |
 +----------------+------------------------+----------------------------------------------+
+| mypy           | use-dmypy              | Use mypy daemon (mypy server) for faster     |
+|                |                        | checks                                       |
++----------------+------------------------+----------------------------------------------+
 | bandit         | config                 | configuration filename                       |
 +----------------+------------------------+----------------------------------------------+
 | bandit         | profile                | profile to use                               |


### PR DESCRIPTION
## Description

Mypy provides an API to use their daemon to speed up type checking. With this change, the `use-dmypy` configuration can be used to toggle usage of that API by prospector.

## Motivation and Context

Mypy tends to be very slow on large repositories, using Mypy daemon makes it much faster.

## How Has This Been Tested?

I've run `prospector --with-tool mypy -t mypy <file>` on a `<file>` in a large repository with and without `use-dmypy` option. The difference was `0.57s` vs `17.44s` in favor of using dmypy.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [ ] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
