### PR TITLE
Fix mypy message with hint

### DIFF
--- a/prospector/tools/mypy/__init__.py
+++ b/prospector/tools/mypy/__init__.py
@@ -129,7 +129,7 @@ class MypyTool(ToolBase):
             mypy_message = json.loads(mypy_json)
             message = f"{mypy_message['message']}."
             if mypy_message.get("hint", ""):
-                message = f"{message}, Hint: {mypy_message['hint']}."
+                message = f"{message} {mypy_message['hint']}."
             code = mypy_message["code"]
             messages.append(
                 Message(


### PR DESCRIPTION
## Description
```
Library stubs not installed for "markdown"., Hint: Hint: "python3 -m pip install types-Markdown". 
```

Became:

```
Library stubs not installed for "markdown". Hint: "python3 -m pip install types-Markdown".
```
