### PR TITLE
Fix enhable/disable on mypy tool

### DIFF
--- a/prospector/tools/mypy/__init__.py
+++ b/prospector/tools/mypy/__init__.py
@@ -102,6 +102,11 @@ class MypyTool(ToolBase):
 
             raise BadToolConfig("mypy", f"The option {name} has an unsupported value type: {type(value)}")
 
+        for code in prospector_config.get_disabled_messages("mypy"):
+            self.options.append(f"--disable-error-code={code}")
+        for code in prospector_config.get_enabled_messages("mypy"):
+            self.options.append(f"--enable-error-code={code}")
+
     def run(self, found_files: FileFinder) -> list[Message]:
         args = [str(path) for path in found_files.python_modules]
         args.extend(self.options)


### PR DESCRIPTION
## Description

Currently, the enable/disable options have no effect on mypy tool => fix it

See also: https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-disable-error-code

## Motivation and Context

Have a good support of mypy :-)

## How Has This Been Tested?

Added the following config on Prospector project:
```
mypy:
  disable:
    - misc
    - attr-defined
    - no-any-return
  options:
    strict: true
```
and run-it :-)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

