### PR TITLE
Avoid exception on missing profile

### DIFF
--- a/prospector/profiles/profile.py
+++ b/prospector/profiles/profile.py
@@ -133,7 +133,10 @@ def _load_content_package(name: str) -> Optional[dict[str, Any]]:
     used_name = None
     for file_name in file_names:
         used_name = f"{module_name}:{file_name}"
-        data = pkgutil.get_data(module_name, file_name)
+        try:
+            data = pkgutil.get_data(module_name, file_name)
+        except (ModuleNotFoundError, FileNotFoundError):
+            continue
         if data is not None:
             break
 


### PR DESCRIPTION
## Description

Avoid exception on missing profile

## Related Issue

Fix #734

## Motivation and Context

Have a cleaner and more understandable output

## How Has This Been Tested?

`prospector --profile=dont_exists.yaml`
=>
```
Failed to run:
Could not find profile dont_exists.yaml
Search path: /home/sbrunner/workspace/prospector:/home/sbrunner/workspace/prospector/prospector/profiles/profiles, or in module 'prospector_profile_dont_exists.yaml'
```

`prospector --profile=utils:dont_exists`
=>
```
Failed to run:
Could not find profile utils:dont_exists.
Search path: /home/sbrunner/workspace/prospector:/home/sbrunner/workspace/prospector/prospector/profiles/profiles, or in module 'prospector_profile_utils'
```

`prospector --profile=utils`
=>
```
Failed to run:
Could not find profile utils.
Search path: /home/sbrunner/workspace/prospector:/home/sbrunner/workspace/prospector/prospector/profiles/profiles, or in module 'prospector_profile_utils'
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
