### PR TITLE
Add GitHub support on formatters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
       - id: ruff
         args:
         - --fix
+        - --ignore=E501
         exclude: |
           (?x)^(
             |tests/.*

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -44,6 +44,9 @@ The default output format of ``prospector`` is designed to be human readable. Yo
 |                      | | ``{path}:{line}:{character}: [{msg_id}({symbol}), {obj}] {msg}``.        |
 |                      | | The output includes the name of the tool which generated the error as    |
 |                      | | as well as the error code.                                               |
+|                      | | On GitHub workflows an annotation is automatically created,              |
+|                      | | if Prospector ir run from a subpath of the repository you can use the    |
+|                      | | PROSPECTOR_FILE_PREFIX environment variable to set the prefix.           |
 +----------------------+----------------------------------------------------------------------------+
 | ``pylint_parseable`` | | Produces output in the same style as ``pylint --parseable``. The         |
 |                      | | format is ``{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}``.          |
@@ -61,6 +64,9 @@ The default output format of ``prospector`` is designed to be human readable. Yo
 | ``xunit``            | | Same as JSON except produces xunit compatible XML output.                |
 +----------------------+----------------------------------------------------------------------------+
 | ``text``             | | The default output format, a simple human readable format.               |
+|                      | | On GitHub workflows an annotation is automatically created,              |
+|                      | | if Prospector ir run from a subpath of the repository you can use the    |
+|                      | | PROSPECTOR_FILE_PREFIX environment variable to set the prefix.           |
 +----------------------+----------------------------------------------------------------------------+
 
 

--- a/prospector/formatters/pylint.py
+++ b/prospector/formatters/pylint.py
@@ -66,6 +66,9 @@ class PylintFormatter(SummaryFormatter):
                 template_args["message"] = ""
                 indent = len(template % template_args)
                 output.append(f"{' ' * indent}See: {message.doc_url}")
+            ci_annotation = self.get_ci_annotation(message)
+            if ci_annotation:
+                output.append(ci_annotation)
         return output
 
     def render(self, summary: bool = True, messages: bool = True, profile: bool = False) -> str:

--- a/prospector/formatters/text.py
+++ b/prospector/formatters/text.py
@@ -24,6 +24,9 @@ class TextFormatter(SummaryFormatter):
         )
 
         output.append(f"    {message.message}")
+        ci_annotation = self.get_ci_annotation(message)
+        if ci_annotation:
+            output.append(ci_annotation)
 
         return "\n".join(output)
 


### PR DESCRIPTION
## Description

Add annotation on GitHub by using [error message](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-error-message)

This is used in PyLint and text formatter.

## Motivation and Context

Have a better support of the GitHub CI

## How Has This Been Tested?

In the pull request I intentionally add an issue and I get:

![image](https://github.com/user-attachments/assets/ede93884-dff2-4072-aa87-4bfd10ea9560)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

