### PR TITLE
Added SARIF formatter

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -4,6 +4,7 @@ Command Line Usage
 .. _issue_16: https://github.com/PyCQA/prospector/issues/16
 .. _vscode_python_plugin: https://marketplace.visualstudio.com/items?itemName=donjayamanne.python
 .. _gitlab_code_climate_report_format: https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format
+.. _sarif_report_format: https://www.oasis-open.org/committees/sarif/charter.php
 
 The simplest way to run prospector is from the project root with no arguments. It will try to figure everything else out itself and provide sensible defaults::
 
@@ -38,6 +39,8 @@ The default output format of ``prospector`` is designed to be human readable. Yo
 | ``vscode``           | | Support for `vscode_python_plugin`_                                      |
 +----------------------+----------------------------------------------------------------------------+
 | ``gitlab``           | | Support for `gitlab_code_climate_report_format`_                         |
++----------------------+----------------------------------------------------------------------------+
+| ``sarif``           | | Support for `sarif_report_format`_                         |
 +----------------------+----------------------------------------------------------------------------+
 | ``grouped``          | | Similar to ``text``, but groups all message on the same line together    |
 |                      | | rather than having a separate entry per message.                         |

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -40,7 +40,7 @@ The default output format of ``prospector`` is designed to be human readable. Yo
 +----------------------+----------------------------------------------------------------------------+
 | ``gitlab``           | | Support for `gitlab_code_climate_report_format`_                         |
 +----------------------+----------------------------------------------------------------------------+
-| ``sarif``           | | Support for `sarif_report_format`_                         |
+| ``sarif``            | | Support for `sarif_report_format`_                                       |
 +----------------------+----------------------------------------------------------------------------+
 | ``grouped``          | | Similar to ``text``, but groups all message on the same line together    |
 |                      | | rather than having a separate entry per message.                         |

--- a/prospector/formatters/__init__.py
+++ b/prospector/formatters/__init__.py
@@ -1,4 +1,4 @@
-from . import emacs, gitlab, grouped, json, pylint, pylint_parseable, text, vscode, xunit, yaml
+from . import emacs, gitlab, grouped, json, pylint, pylint_parseable, sarif, text, vscode, xunit, yaml
 from .base import Formatter
 
 __all__ = ("FORMATTERS", "Formatter")
@@ -15,4 +15,5 @@ FORMATTERS: dict[str, type[Formatter]] = {
     "pylint_parseable": pylint_parseable.PylintParseableFormatter,
     "xunit": xunit.XunitFormatter,
     "vscode": vscode.VSCodeFormatter,
+    "sarif": sarif.SarifFormatter,
 }

--- a/prospector/formatters/sarif.py
+++ b/prospector/formatters/sarif.py
@@ -1,0 +1,63 @@
+import importlib
+import json
+from typing import Any
+
+from prospector.formatters.base import Formatter
+
+__all__ = ("SarifFormatter",)
+
+_VERSION = importlib.metadata.version("prospector")
+
+
+class SarifFormatter(Formatter):
+    """
+    This formatter outputs messages in the SARIF format.
+    https://www.oasis-open.org/committees/sarif/charter.php
+    """
+    def render(self, summary: bool = True, messages: bool = True, profile: bool = False) -> str:
+        output: list[dict[str, Any]] = []
+
+        if messages:
+            for message in sorted(self.messages):
+                output.append(
+                    {
+                        "ruleId": message.code,
+                        "level": "warning",
+                        "message": {
+                            "text": f"{message.source}[{message.code}]: {message.message.strip()}"
+                        },
+                        "locations": [
+                            {
+                                "physicalLocation": {
+                                    "artifactLocation": {
+                                        "uri": str(self._make_path(message.location))
+                                    }
+                                },
+                                "region": {
+                                    "startLine": message.location.line,
+                                    "endLine": message.location.line_end,
+                                    "startColumn": message.location.character,
+                                    "endColumn": message.location.character_end
+                                }
+                            }
+                        ]
+                    }
+                )
+
+        sarif_skeleton = {
+            "version": "2.1.0",
+            "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",
+            "runs": [
+                {
+                    "tool": {
+                        "driver": {
+                            "name": "Prospector",
+                            "informationUri": "https://github.com/prospector-dev/prospector",
+                            "version": _VERSION
+                        }
+                    }
+                }
+            ]
+        }
+
+        return json.dumps(sarif_skeleton, indent=2)

--- a/prospector/formatters/sarif.py
+++ b/prospector/formatters/sarif.py
@@ -52,7 +52,8 @@ class SarifFormatter(Formatter):
                             "informationUri": "https://github.com/prospector-dev/prospector",
                             "version": _VERSION,
                         }
-                    }
+                    },
+                    "results": output,
                 }
             ],
         }

--- a/prospector/formatters/sarif.py
+++ b/prospector/formatters/sarif.py
@@ -16,11 +16,21 @@ class SarifFormatter(Formatter):
     """
 
     def render(self, summary: bool = True, messages: bool = True, profile: bool = False) -> str:
-        output: list[dict[str, Any]] = []
+        results: list[dict[str, Any]] = []
 
         if messages:
             for message in sorted(self.messages):
-                output.append(
+                region: dict[str, int] = {}
+                if message.location.line:
+                    region["startLine"] = message.location.line
+                if message.location.line_end:
+                    region["endLine"] = message.location.line_end
+                if message.location.character:
+                    region["startColumn"] = message.location.character
+                if message.location.character_end:
+                    region["endColumn"] = message.location.character_end
+
+                results.append(
                     {
                         "ruleId": message.code,
                         "level": "warning",
@@ -28,22 +38,17 @@ class SarifFormatter(Formatter):
                         "locations": [
                             {
                                 "physicalLocation": {
-                                    "artifactLocation": {"uri": str(self._make_path(message.location))}
-                                },
-                                "region": {
-                                    "startLine": message.location.line,
-                                    "endLine": message.location.line_end,
-                                    "startColumn": message.location.character,
-                                    "endColumn": message.location.character_end,
-                                },
+                                    "artifactLocation": {"uri": str(self._make_path(message.location))},
+                                    "region": region,
+                                }
                             }
                         ],
                     }
                 )
 
-        sarif_skeleton = {
+        output = {
             "version": "2.1.0",
-            "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",
+            "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
             "runs": [
                 {
                     "tool": {
@@ -53,9 +58,9 @@ class SarifFormatter(Formatter):
                             "version": _VERSION,
                         }
                     },
-                    "results": output,
+                    "results": results,
                 }
             ],
         }
 
-        return json.dumps(sarif_skeleton, indent=2)
+        return json.dumps(output, indent=2)

--- a/prospector/formatters/sarif.py
+++ b/prospector/formatters/sarif.py
@@ -14,6 +14,7 @@ class SarifFormatter(Formatter):
     This formatter outputs messages in the SARIF format.
     https://www.oasis-open.org/committees/sarif/charter.php
     """
+
     def render(self, summary: bool = True, messages: bool = True, profile: bool = False) -> str:
         output: list[dict[str, Any]] = []
 
@@ -23,24 +24,20 @@ class SarifFormatter(Formatter):
                     {
                         "ruleId": message.code,
                         "level": "warning",
-                        "message": {
-                            "text": f"{message.source}[{message.code}]: {message.message.strip()}"
-                        },
+                        "message": {"text": f"{message.source}[{message.code}]: {message.message.strip()}"},
                         "locations": [
                             {
                                 "physicalLocation": {
-                                    "artifactLocation": {
-                                        "uri": str(self._make_path(message.location))
-                                    }
+                                    "artifactLocation": {"uri": str(self._make_path(message.location))}
                                 },
                                 "region": {
                                     "startLine": message.location.line,
                                     "endLine": message.location.line_end,
                                     "startColumn": message.location.character,
-                                    "endColumn": message.location.character_end
-                                }
+                                    "endColumn": message.location.character_end,
+                                },
                             }
-                        ]
+                        ],
                     }
                 )
 
@@ -53,11 +50,11 @@ class SarifFormatter(Formatter):
                         "driver": {
                             "name": "Prospector",
                             "informationUri": "https://github.com/prospector-dev/prospector",
-                            "version": _VERSION
+                            "version": _VERSION,
                         }
                     }
                 }
-            ]
+            ],
         }
 
         return json.dumps(sarif_skeleton, indent=2)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add SARIF formatter

## Related Issue

#820 

## Motivation and Context

When running prospector on GitHub CI/CD, it is not possible to use its report as is, because GitHub uses the "SARIF report format", which is not supported.

## How Has This Been Tested?

I tested these changes and got the expected result.

<img width="997" height="369" alt="image" src="https://github.com/user-attachments/assets/de531de2-4758-4a57-bea5-ffc05985eca6" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [ ] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
