### PR TITLE
Fix capture mypy stderr output on fatal options error instead of generic message

### DIFF
--- a/prospector/run.py
+++ b/prospector/run.py
@@ -113,7 +113,8 @@ class Prospector:
                 loc = Location(self.config.workdir, None, None, None, None)
                 msg = (
                     f"Tool {toolname} failed to run "
-                    f"(exception was raised, re-run prospector with -X to see the stacktrace)"
+                    "(exception was raised, re-run prospector with --direct-tool-stdout to better see the tool error "
+                    "or --die-on-tool-error to see the stacktrace)"
                 )
                 message = Message(
                     toolname,

--- a/prospector/tools/mypy/__init__.py
+++ b/prospector/tools/mypy/__init__.py
@@ -126,25 +126,7 @@ class MypyTool(ToolBase):
 
     def _run_std(self, args: list[str]) -> list[Message]:
         messages = []
-        try:
-            sources, options = mypy.main.process_options(args, fscache=self.fscache)
-        except (SystemExit, Exception) as e:
-            message = "The error(s) will be displayed before the messages" if isinstance(e, SystemExit) else str(e)
-            messages.append(
-                Message(
-                    "mypy",
-                    code="fatal-options-error",
-                    message=message,
-                    location=Location(
-                        path="",
-                        module=None,
-                        function=None,
-                        line=0,
-                        character=0,
-                    ),
-                )
-            )
-            return messages
+        sources, options = mypy.main.process_options(args, fscache=self.fscache)
         options.output = "json"
         try:
             res = mypy.build.build(sources, options, fscache=self.fscache)

--- a/prospector/tools/pyroma/__init__.py
+++ b/prospector/tools/pyroma/__init__.py
@@ -46,7 +46,7 @@ PYROMA_ALL_CODES = {
     "BusFactor": "PYR19",
 }
 
-PYROMA_CODES = {}
+PYROMA_CODES: dict[str, str] = {}
 
 
 def _copy_codes() -> None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Example of new output:
```
************* Module .
.:0:0: fatal-options-error(mypy): usage: mypy [-h] [-v] [-V] [more options; see below]
            [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]
mypy: error: argument --python-version: Python 3.9 is not supported (must be 3.10 or higher)

Check Information
=================
         Started: 2026-07-02 11:47:24.052039
        Finished: 2026-07-02 11:47:24.214779
      Time Taken: 0.16 seconds
       Formatter: pylint
        Profiles: .prospector.yaml, utils:base, utils:base-all, strictness_none, member_warnings, utils:no-design-checks, utils:fix, duplicated, duplicated:ruff, duplicated:black, duplicated:isort, no_doc_warnings, no_test_warnings
      Strictness: from profile
  Libraries Used: 
       Tools Run: mypy
  Messages Found: 1

```

## Related Issue

Probably fix: #825 I don't have the exact same issue. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Run in a project that has a mypy error

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [ ] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
