### PR TITLE
fix: match ignore-paths against a symlink's own name

### DIFF
--- a/prospector/config/__init__.py
+++ b/prospector/config/__init__.py
@@ -53,16 +53,19 @@ class ProspectorConfig:
         ignores, workdir = self.ignores, self.workdir
 
         def _filter(path: Path) -> bool:
-            for ignore in ignores:
-                # first figure out where the path is, relative to the workdir
-                # ignore-paths/patterns will usually be relative to a repository
-                # root or the CWD, but the path passed to prospector may not be
-                path = path.resolve().absolute()
-                if is_relative_to(path, workdir):
-                    path = path.relative_to(workdir)
-                if ignore.match(str(path)):
-                    return True
-            return False
+            # first figure out where the path is, relative to the workdir
+            # ignore-paths/patterns will usually be relative to a repository
+            # root or the CWD, but the path passed to prospector may not be.
+            # A symlink is matched under its own name as well as its target,
+            # since users expect to be able to ignore the link they can see.
+            candidates = []
+            for candidate in (path.absolute(), path.resolve().absolute()):
+                if is_relative_to(candidate, workdir):
+                    candidate = candidate.relative_to(workdir)
+                if candidate not in candidates:
+                    candidates.append(candidate)
+
+            return any(ignore.match(str(candidate)) for ignore in ignores for candidate in candidates)
 
         return _filter
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -19,6 +19,25 @@ def test_relative_ignores() -> None:
         assert len(files.python_modules) == 2
 
 
+def test_symlinked_ignore_path(tmp_path: Path) -> None:
+    """
+    Tests that 'ignore-paths: <symlink name>' ignores the symlink itself,
+    not only the path its target resolves to.
+    """
+    target = tmp_path / "realdir"
+    target.mkdir()
+    (target / "module.py").write_text("x = 1\n")
+    (tmp_path / "link").symlink_to(target, target_is_directory=True)
+    (tmp_path / "profile_symlink_ignores.yml").write_text("ignore-paths:\n  - link\n")
+
+    with patch_execution("-P", "profile_symlink_ignores.yml", set_cwd=tmp_path):
+        config = ProspectorConfig()
+        exclusion_filter = config.make_exclusion_filter()
+
+    assert exclusion_filter(tmp_path / "link")
+    assert exclusion_filter(tmp_path / "link" / "module.py")
+
+
 def test_determine_ignores_all_str() -> None:
     with patch_execution("-P", "prospector-str-ignores", set_cwd=Path(__file__).parent):
         config = ProspectorConfig()


### PR DESCRIPTION
Closes #608

## Description

`make_exclusion_filter` called `path.resolve()` before matching the ignore
patterns, which dereferences symlinks. As a result a symlink could only be
excluded by naming its target, never by the link name the user actually sees
in the tree. The filter now matches against both the path as given and its
resolved target (each made relative to the workdir where applicable).

## Related Issue

#608 — "[BUG] ignore-paths/patterns do not work with symbolic link names"

## Motivation and Context

Adding a symlink's name to `ignore-paths` or `ignore-patterns` silently did
nothing, so the linted file set included directories the user had explicitly
excluded. Matching the link name is what the configuration reads as, and the
target is still matched too, so existing configurations keep working.

## How Has This Been Tested?

Added `test_symlinked_ignore_path` to `tests/config/test_config.py`. It creates
a directory, a symlink to it, and a profile with `ignore-paths: [link]`, then
asserts the filter excludes the symlink and a file under it. The test fails on
the unpatched filter (`AssertionError: assert False`) and passes with the fix.
`tests/config` and `tests/finder` pass (30 passed); `ruff check` and
`ruff format` are unchanged from baseline on the touched files.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the dependencies
- [ ] I have updated the dependencies accordingly
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
